### PR TITLE
Remove unavaiable usage from the code snippet in READEME

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ import { SlackAPI } from "https://deno.land/x/deno_slack_api@0.0.5/mod.ts"
 
 const client = SlackAPI(token);
 
-const response = await client.chat.postMessage({
-  text: "hello there",
-  channel: "...",
-});
-
-// use client.apiCall() directly with the api method name
 await client.apiCall("chat.postMessage", {
   text: "hello there",
   channel: "...",


### PR DESCRIPTION
###  Summary

If I understand correctly, the type-safe method calls are not available at this moment.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
