### PR TITLE
Use deps.ts and dev_deps.ts.

### DIFF
--- a/scripts/src/api-method-node.ts
+++ b/scripts/src/api-method-node.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from "https://deno.land/x/case@v2.1.0/mod.ts";
+import { pascalCase } from "./deps.ts";
 
 export class APIMethodNode {
   name = "";

--- a/scripts/src/deps.ts
+++ b/scripts/src/deps.ts
@@ -1,0 +1,1 @@
+export { pascalCase } from "https://deno.land/x/case@2.1.1/mod.ts";

--- a/scripts/src/generate.ts
+++ b/scripts/src/generate.ts
@@ -1,5 +1,5 @@
-import { pascalCase } from "https://deno.land/x/case@v2.1.0/mod.ts";
 import { APIMethodNode } from "./api-method-node.ts";
+import { pascalCase } from "./deps.ts";
 
 const run = async () => {
   const text = await Deno.readTextFile("./scripts/api_spec.json");
@@ -134,7 +134,7 @@ const getTestCode = (api: APIMethodNode) => {
   visitMethodNodes(api);
 
   return `
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.134.0/testing/asserts.ts";
 import { SlackAPI } from "../mod.ts";
 
 Deno.test("SlackAPI", () => {

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -1,10 +1,6 @@
-import {
-  assertEquals,
-  assertRejects,
-} from "https://deno.land/std@0.132.0/testing/asserts.ts";
-import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 import { SlackAPI } from "./mod.ts";
 import { serializeData } from "./base-client.ts";
+import { assertEquals, assertRejects, mf } from "./dev_deps.ts";
 
 Deno.test("SlackAPI class", async (t) => {
   mf.install(); // mock out calls to `fetch`

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,0 +1,5 @@
+export {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.134.0/testing/asserts.ts";
+export * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";


### PR DESCRIPTION
It is a good practice to centralise Deno dependencies within `deps.ts` and `dev_deps.ts` files.
See https://deno.land/manual/examples/manage_dependencies

---

Related to https://github.com/slackapi/deno-slack-builder/pull/14 and https://github.com/slackapi/deno-slack-sdk/pull/14

---

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
