### PR TITLE
Add the `workflows.triggers.create` method to the client without typing

### DIFF
--- a/scripts/src/public-api-methods.ts
+++ b/scripts/src/public-api-methods.ts
@@ -223,6 +223,7 @@ export const getPublicAPIMethods = () => {
 
   // upcoming platform 2.0 methods we want available but aren't listed quite yet
   const platform2Methods = [
+    "workflows.triggers.create",
     "functions.completeError",
     "functions.completeSuccess",
     "apps.datastore.delete",

--- a/src/generated/method-types/api_method_types_test.ts
+++ b/src/generated/method-types/api_method_types_test.ts
@@ -262,5 +262,6 @@ Deno.test("SlackAPIMethodsType generated types", () => {
   assertEquals(typeof client.views.update, "function");
   assertEquals(typeof client.workflows.stepCompleted, "function");
   assertEquals(typeof client.workflows.stepFailed, "function");
+  assertEquals(typeof client.workflows.triggers.create, "function");
   assertEquals(typeof client.workflows.updateStep, "function");
 });

--- a/src/generated/method-types/workflows.ts
+++ b/src/generated/method-types/workflows.ts
@@ -3,5 +3,8 @@ import { SlackAPIMethod } from "../../types.ts";
 export type WorkflowsAPIType = {
   stepCompleted: SlackAPIMethod;
   stepFailed: SlackAPIMethod;
+  triggers: {
+    create: SlackAPIMethod;
+  };
   updateStep: SlackAPIMethod;
 };


### PR DESCRIPTION
###  Summary

Add `workflows.triggers.create` to the `client`.

#### Details
This will allow an untyped version of `client.workflows.triggers.create`. See example `shortcut` trigger type usage:

```ts
const client = SlackAPI(token, {
    slackApiUrl: env["SLACK_API_URL"],
  });

await client.workflows.triggers.create({
    "type": "shortcut",
    "workflow": "#/workflows/send_message", // You should probably pass your own workflow here
    "inputs": {
      "channel": {
        "value": "C013BUS924T", // You should probably pass your own channel here
      },
    },
    "shortcut": {
      name: "Send a message",
      description: "This will send a message",
    },
  });
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
