### PR TITLE
Export slack client

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "https://deno.land": false
   },
   "[typescript]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": true,
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
   "editor.tabSize": 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "https://deno.land": false
   },
   "[typescript]": {
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
   "editor.tabSize": 2

--- a/src/api-proxy.ts
+++ b/src/api-proxy.ts
@@ -1,10 +1,5 @@
 import { BaseSlackAPIClient } from "./base-client.ts";
-import {
-  APIProxyResponse,
-  BaseResponse,
-  BaseSlackClient,
-  SlackAPIMethodArgs,
-} from "./types.ts";
+import { BaseResponse, SlackAPIClient, SlackAPIMethodArgs } from "./types.ts";
 
 type APICallback = {
   (method: string, payload?: SlackAPIMethodArgs): Promise<BaseResponse>;
@@ -35,7 +30,7 @@ export const APIProxy = (
   rootClient: any | null,
   apiCallback: APICallback,
   ...path: (string | undefined)[]
-): APIProxyResponse => {
+): SlackAPIClient => {
   const method = path.filter(Boolean).join(".");
 
   // We either proxy the object passed in, which we do for the top level client,

--- a/src/api-proxy.ts
+++ b/src/api-proxy.ts
@@ -1,7 +1,10 @@
 import { BaseSlackAPIClient } from "./base-client.ts";
-import { BaseResponse, SlackAPIMethodArgs } from "./types.ts";
-import { TypedSlackAPIMethodsType } from "./typed-method-types/mod.ts";
-import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
+import {
+  APIProxyResponse,
+  BaseResponse,
+  BaseSlackClient,
+  SlackAPIMethodArgs,
+} from "./types.ts";
 
 type APICallback = {
   (method: string, payload?: SlackAPIMethodArgs): Promise<BaseResponse>;
@@ -13,7 +16,7 @@ export const ProxifyAndTypeClient = (baseClient: BaseSlackAPIClient) => {
     return baseClient.apiCall(method, payload);
   };
 
-  // Create a subest of the client that we want to wrap our Proxy() around
+  // Create a subset of the client that we want to wrap our Proxy() around
   const clientToProxy = {
     apiCall: baseClient.apiCall.bind(baseClient),
     response: baseClient.response.bind(baseClient),
@@ -23,8 +26,7 @@ export const ProxifyAndTypeClient = (baseClient: BaseSlackAPIClient) => {
   const client = APIProxy(
     clientToProxy,
     apiCallHandler,
-  ) as typeof clientToProxy & TypedSlackAPIMethodsType & SlackAPIMethodsType;
-
+  );
   return client;
 };
 
@@ -33,8 +35,7 @@ export const APIProxy = (
   rootClient: any | null,
   apiCallback: APICallback,
   ...path: (string | undefined)[]
-  // deno-lint-ignore no-explicit-any
-): any => {
+): APIProxyResponse => {
   const method = path.filter(Boolean).join(".");
 
   // We either proxy the object passed in, which we do for the top level client,

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -63,9 +63,11 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Objects/arrays, numbers and booleans get stringified
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
+
     const serializedValue: string =
       (typeof value !== "string" ? JSON.stringify(value) : value);
     encodedData[key] = serializedValue;
   });
+
   return new URLSearchParams(encodedData);
 }

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -65,7 +65,9 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
 
     const serializedValue: string =
-      (typeof value !== "string" ? JSON.stringify(value) : value);
+      (typeof value !== "string" 
+    ? JSON.stringify(value) 
+    : value);
     encodedData[key] = serializedValue;
   });
 

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -64,8 +64,9 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
 
-    const serializedValue: string =
-      (typeof value !== "string" ? JSON.stringify(value) : value);
+    const serializedValue: string = (typeof value !== "string"
+      ? JSON.stringify(value)
+      : value);
     encodedData[key] = serializedValue;
   });
 

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -1,6 +1,11 @@
-import { BaseResponse, SlackAPIMethodArgs, SlackAPIOptions } from "./types.ts";
+import {
+  BaseResponse,
+  BaseSlackClient,
+  SlackAPIMethodArgs,
+  SlackAPIOptions,
+} from "./types.ts";
 
-export class BaseSlackAPIClient {
+export class BaseSlackAPIClient implements BaseSlackClient {
   #token?: string;
   #baseURL: string;
 
@@ -58,9 +63,8 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Objects/arrays, numbers and booleans get stringified
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
-    const serializedValue: string = (typeof value !== "string"
-      ? JSON.stringify(value)
-      : value);
+    const serializedValue: string =
+      (typeof value !== "string" ? JSON.stringify(value) : value);
     encodedData[key] = serializedValue;
   });
   return new URLSearchParams(encodedData);

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -65,9 +65,7 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
 
     const serializedValue: string =
-      (typeof value !== "string" 
-    ? JSON.stringify(value) 
-    : value);
+      (typeof value !== "string" ? JSON.stringify(value) : value);
     encodedData[key] = serializedValue;
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,21 @@ export type BaseResponse = {
   [otherOptions: string]: unknown;
 };
 
+export type BaseSlackClient = {
+  apiCall: APIProxyCall;
+  response: APIProxyResponse;
+};
+
+export type APIProxyResponse = (
+  url: string,
+  data: Record<string, unknown>,
+) => Promise<BaseResponse>;
+
+export type APIProxyCall = (
+  method: string,
+  data?: SlackAPIMethodArgs,
+) => Promise<BaseResponse>;
+
 export type SlackAPIOptions = {
   /**
    * @description Optional url endpoint for the Slack API used for api calls. Defaults to https://slack.com/api/

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import { TypedSlackAPIMethodsType } from "./typed-method-types/mod.ts";
+import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
+
 export type BaseResponse = {
   /** `true` if the response from the server was successful, `false` otherwise. */
   ok: boolean;
@@ -13,19 +16,24 @@ export type BaseResponse = {
   [otherOptions: string]: unknown;
 };
 
+export type SlackAPIClient =
+  & BaseSlackClient
+  & TypedSlackAPIMethodsType
+  & SlackAPIMethodsType;
+
 export type BaseSlackClient = {
-  apiCall: APIProxyCall;
-  response: APIProxyResponse;
+  apiCall: BaseClientCall;
+  response: BaseClientResponse;
 };
 
-export type APIProxyResponse = (
-  url: string,
-  data: Record<string, unknown>,
-) => Promise<BaseResponse>;
-
-export type APIProxyCall = (
+type BaseClientCall = (
   method: string,
   data?: SlackAPIMethodArgs,
+) => Promise<BaseResponse>;
+
+type BaseClientResponse = (
+  url: string,
+  data: Record<string, unknown>,
 ) => Promise<BaseResponse>;
 
 export type SlackAPIOptions = {


### PR DESCRIPTION
###  Summary

Currently the SlackAPIClient is being exported as type ```any```, the purpose of these changes is to create a ```SlackAPIClient``` type that will allow it to be passed around more easily.
https://jira.tinyspeck.com/browse/HERMES-3010
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
