### PR TITLE
Change Deno version and run fmt

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.20.6
+          deno-version: v1.x
 
       # Uncomment this step to verify the use of 'deno fmt' on each commit.
       - name: Verify formatting

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -64,9 +64,8 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
 
-    const serializedValue: string = (typeof value !== "string"
-      ? JSON.stringify(value)
-      : value);
+    const serializedValue: string =
+      (typeof value !== "string" ? JSON.stringify(value) : value);
     encodedData[key] = serializedValue;
   });
 


### PR DESCRIPTION
###  Summary

This is the only repo specifying a deno version, so I'm removing the specification so we don't need to switch deno versions to work with this library.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
