### PR TITLE
Add uploading of codecov reports

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -27,12 +27,13 @@ jobs:
         with:
           deno-version: v1.x
 
-      # Uncomment this step to verify the use of 'deno fmt' on each commit.
-      - name: Verify formatting
-        run: deno fmt --check src
+      - name: Run formatter, linter and tests
+        run: deno task test
 
-      - name: Run linter
-        run: deno lint src
+      - name: Generate CodeCov-friendly coverage report
+        run: deno task coverage --lcov --output=codecov.lcov
 
-      - name: Run tests
-        run: deno test src
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          file: ./codecov.lcov

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,6 +11,6 @@
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test src",
-    "coverage": "deno test --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test --exclude=src/generated .coverage"
+    "coverage": "deno test --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test --exclude=src/generated .coverage"
   }
 }


### PR DESCRIPTION
Also use the same deno tasks for testing/formatting/linting as maintainers would in CI