### PR TITLE
Add support for filter in webhooks

### DIFF
--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -18,7 +18,8 @@ export type BaseTrigger = {
   /** @description The workflow that the trigger initiates */
   workflow: string;
   /** @description The inputs provided to the workflow */
-  inputs?: Record<string, unknown>;
+  // deno-lint-ignore no-explicit-any
+  inputs?: Record<string, any>;
   /** @description The name of the trigger */
   name: string;
   /** @description The description of the trigger */

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -12,14 +12,18 @@ export const TriggerTypes = {
   Webhook: "webhook",
 } as const;
 
+type WorkflowInput = {
+  // deno-lint-ignore no-explicit-any
+  value: any;
+};
+
 export type BaseTrigger = {
   /** @description The type of trigger */
   type: typeof TriggerTypes[keyof typeof TriggerTypes];
   /** @description The workflow that the trigger initiates */
   workflow: string;
   /** @description The inputs provided to the workflow */
-  // deno-lint-ignore no-explicit-any
-  inputs?: Record<string, any>;
+  inputs?: Record<string, WorkflowInput>;
   /** @description The name of the trigger */
   name: string;
   /** @description The description of the trigger */

--- a/src/typed-method-types/workflows/triggers/trigger-filter.ts
+++ b/src/typed-method-types/workflows/triggers/trigger-filter.ts
@@ -1,0 +1,38 @@
+export const TriggerFilterOperatorType = {
+  AND: "AND",
+  OR: "OR",
+  NOT: "NOT",
+} as const;
+
+export type FilterType = {
+  /** @default 1 */
+  version?: number;
+  root: TriggerFilterDefinition;
+};
+
+type TriggerFilterDefinition =
+  | TriggerFilterBooleanLogic
+  | TriggerFilterComparator;
+
+// Boolean Logic
+
+type TriggerFilterBooleanLogic = {
+  /**
+   * @description The logical operator to run against your filter inputs
+   * @example "AND" */
+  operator: TriggerFilterOperatorTypeValues;
+  /**  @description The filter inputs that contain filter statement definitions */
+  inputs: [TriggerFilterDefinition, ...TriggerFilterDefinition[]];
+};
+
+type TriggerFilterOperatorTypeValues =
+  typeof TriggerFilterOperatorType[keyof typeof TriggerFilterOperatorType];
+
+// Comparator
+
+type TriggerFilterComparator = {
+  /** @description Comparison of values */
+  statement: string;
+  operator?: never;
+  inputs?: never;
+};

--- a/src/typed-method-types/workflows/triggers/trigger-filter.ts
+++ b/src/typed-method-types/workflows/triggers/trigger-filter.ts
@@ -23,6 +23,7 @@ type TriggerFilterBooleanLogic = {
   operator: TriggerFilterOperatorTypeValues;
   /**  @description The filter inputs that contain filter statement definitions */
   inputs: [TriggerFilterDefinition, ...TriggerFilterDefinition[]];
+  statement?: never;
 };
 
 type TriggerFilterOperatorTypeValues =

--- a/src/typed-method-types/workflows/triggers/trigger-filter_test.ts
+++ b/src/typed-method-types/workflows/triggers/trigger-filter_test.ts
@@ -1,0 +1,66 @@
+import {
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.99.0/testing/asserts.ts";
+import { FilterType, TriggerFilterOperatorType } from "./trigger-filter.ts";
+
+Deno.test("Trigger Filters can use a single statement", () => {
+  const filter: FilterType = {
+    root: {
+      statement: "1 === 1",
+    },
+  };
+  assertEquals(filter.root.statement, "1 === 1");
+});
+
+Deno.test("Trigger Filters can use simple logical operators", () => {
+  const filter: FilterType = {
+    root: {
+      operator: "OR",
+      inputs: [{
+        statement: "1 === 2",
+      }, {
+        statement: "2 === 2",
+      }],
+    },
+  };
+  assertEquals(filter.root.operator, TriggerFilterOperatorType.OR);
+  assertEquals(filter.root.inputs?.length, 2);
+  filter.root.inputs?.forEach((input) => {
+    assertExists(input.statement);
+  });
+});
+
+Deno.test("Trigger Filters can use nested logical operators", () => {
+  const filter: FilterType = {
+    root: {
+      operator: TriggerFilterOperatorType.OR,
+      inputs: [{
+        statement: "1 === 2",
+      }, {
+        statement: "2 === 3",
+      }, {
+        operator: "AND",
+        inputs: [{
+          statement: "3 === 3",
+        }, {
+          operator: "OR",
+          inputs: [{
+            statement: "3 === 4",
+          }, {
+            statement: "4 === 4",
+          }],
+        }],
+      }],
+    },
+  };
+  assertEquals(filter.root.operator, TriggerFilterOperatorType.OR);
+  filter.root.inputs?.forEach((input) => {
+    assertExists(input.statement || (input.operator && input.inputs));
+    input.inputs?.forEach((nestedInput) => {
+      assertExists(
+        nestedInput.statement || (nestedInput.operator && nestedInput.inputs),
+      );
+    });
+  });
+});

--- a/src/typed-method-types/workflows/triggers/webhook.ts
+++ b/src/typed-method-types/workflows/triggers/webhook.ts
@@ -1,4 +1,5 @@
 import { BaseTrigger, RequiredInputs, TriggerTypes } from "./mod.ts";
+import { FilterType } from "./trigger-filter.ts";
 
 export type WebhookTrigger =
   & BaseTrigger
@@ -6,7 +7,7 @@ export type WebhookTrigger =
   & {
     type: typeof TriggerTypes.Webhook;
     webhook?: {
-      // deno-lint-ignore no-explicit-any
-      filter?: Record<string, any>;
+      /** @description Defines the condition in which this webhook trigger should execute the Workflow */
+      filter?: FilterType;
     };
   };

--- a/src/typed-method-types/workflows/triggers/webhook_test.ts
+++ b/src/typed-method-types/workflows/triggers/webhook_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+import { WebhookTrigger } from "./webhook.ts";
+import { TriggerTypes } from "./mod.ts";
+
+Deno.test("Webhook Triggers can set the type using the string", () => {
+  const webhook: WebhookTrigger = {
+    type: "webhook",
+    name: "test",
+    workflow: "example",
+    inputs: {},
+  };
+  assertEquals(webhook.type, TriggerTypes.Webhook);
+});
+
+Deno.test("Webhook Triggers can set the type using the TriggerTypes object", () => {
+  const webhook: WebhookTrigger = {
+    type: TriggerTypes.Webhook,
+    name: "test",
+    workflow: "example",
+    inputs: {},
+  };
+  assertEquals(webhook.type, TriggerTypes.Webhook);
+});
+
+Deno.test("Webhook Trigger Filters support an optional webhook object", () => {
+  const webhook: WebhookTrigger = {
+    type: TriggerTypes.Webhook,
+    name: "test",
+    workflow: "example",
+    inputs: {},
+    webhook: {
+      filter: {
+        root: {
+          statement: "1 === 1",
+        },
+      },
+    },
+  };
+  assertEquals(typeof webhook.webhook, "object");
+});


### PR DESCRIPTION
###  Summary
Defines the filter type and uses that filter type in webhook triggers

#### Testing
In order to test this, point your app to this branch (locally or [the raw github url](https://raw.githubusercontent.com/slackapi/deno-slack-api/33940235b6d61ced53f21acd4931d847d2c0006f/src/mod.ts)), instantiate your `client` within a runtime function definition and use `client.workflows.triggers.create` to create a Webhook trigger.

Hopefully typeahead will guide you, but in case you need an example of a valid webhook trigger with a filter, here's one below:
```ts
const client = SlackAPI(token);

await client.workflows.triggers.create({
    type: "webhook",
    name: "sample event",
    workflow: "#/workflows/send_message",
    inputs: {},
    webhook: {
      filter: {
        root: {
          operator: "OR",
          inputs: [{
            statement: "3 === 1",
          }, {
            operator: "AND",
            inputs: [{
              statement: "3 === 3",
            }, {
              statement: "1 === 1",
            }],
          }],
        },
      },
    },
  });
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
