### PR TITLE
Add specificity to typing for Scheduled Triggers

### DIFF
--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -1,6 +1,6 @@
 import { BaseMethodArgs, BaseResponse } from "../../../types.ts";
 import { EventTrigger } from "./event.ts";
-import { ScheduledTrigger } from "./schedule.ts";
+import { ScheduledTrigger } from "./scheduled.ts";
 import { ShortcutTrigger } from "./shortcut.ts";
 import { WebhookTrigger } from "./webhook.ts";
 

--- a/src/typed-method-types/workflows/triggers/schedule.ts
+++ b/src/typed-method-types/workflows/triggers/schedule.ts
@@ -1,9 +1,29 @@
 import { BaseTrigger, RequiredInputs, TriggerTypes } from "./mod.ts";
+
+const SCHEDULE_FREQUENCY = {
+  Daily: "daily",
+  Weekly: "weekly",
+  Monthly: "monthly",
+  Yearly: "yearly",
+} as const;
+
+const WEEKDAYS = {
+  Monday: "Monday",
+  Tuesday: "Tuesday",
+  Wednesday: "Wednesday",
+  Thursday: "Thursday",
+  Friday: "Friday",
+  Saturday: "Saturday",
+  Sunday: "Sunday",
+} as const;
+
+type Frequency = typeof SCHEDULE_FREQUENCY[keyof typeof SCHEDULE_FREQUENCY];
+
 type BaseFrequencyType = {
   /** @description How often the trigger will activate */
-  type: string;
+  type: Frequency;
   /** @description The days of the week the trigger should activate on (not available for daily triggers) */
-  on_days?: string;
+  on_days?: (typeof WEEKDAYS[keyof typeof WEEKDAYS])[];
   /** @description How often the trigger will repeat, respective to the frequency type */
   repeats_every?: number;
   /**
@@ -12,7 +32,30 @@ type BaseFrequencyType = {
   on_week_num?: number;
 };
 
-type FrequencyType = BaseFrequencyType;
+type DailyFrequencyType =
+  & {
+    /** @description How often the trigger will activate */
+    type: typeof SCHEDULE_FREQUENCY.Daily;
+  }
+  & Pick<BaseFrequencyType, "repeats_every">;
+
+type WeeklyFrequencyType = {
+  /** @description How often the trigger will activate */
+  type: typeof SCHEDULE_FREQUENCY.Weekly;
+} & Pick<BaseFrequencyType, "on_days" | "repeats_every">;
+
+type MonthlyOrYearlyFrequencyType = {
+  /** @description How often the trigger will activate */
+  type: Extract<
+    Frequency,
+    typeof SCHEDULE_FREQUENCY.Monthly | typeof SCHEDULE_FREQUENCY.Yearly
+  >;
+} & Omit<BaseFrequencyType, "type">;
+
+type FrequencyType =
+  | MonthlyOrYearlyFrequencyType
+  | DailyFrequencyType
+  | WeeklyFrequencyType;
 
 export type ScheduledTrigger =
   & BaseTrigger

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -1,13 +1,13 @@
 import { BaseTrigger, RequiredInputs, TriggerTypes } from "./mod.ts";
 
-const SCHEDULE_FREQUENCY = {
+export const SCHEDULE_FREQUENCY = {
   Daily: "daily",
   Weekly: "weekly",
   Monthly: "monthly",
   Yearly: "yearly",
 } as const;
 
-const WEEKDAYS = {
+export const WEEKDAYS = {
   Monday: "Monday",
   Tuesday: "Tuesday",
   Wednesday: "Wednesday",

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -51,7 +51,7 @@ type MonthlyFrequencyType = {
   type: typeof SCHEDULE_FREQUENCY.Monthly;
   /** @description The days of the week the trigger should activate on (not available for daily triggers) */
   on_days?: [WeekdayUnion];
-} & Omit<BaseFrequencyType, "type" | "on_days">;
+} & Pick<BaseFrequencyType, "repeats_every" | "on_week_num">;
 
 type YearlyFrequencyType = {
   /** @description How often the trigger will activate */

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -53,28 +53,42 @@ type MonthlyOrYearlyFrequencyType = {
 } & Omit<BaseFrequencyType, "type">;
 
 type FrequencyType =
-  | MonthlyOrYearlyFrequencyType
   | DailyFrequencyType
-  | WeeklyFrequencyType;
+  | WeeklyFrequencyType
+  | MonthlyOrYearlyFrequencyType;
 
-export type ScheduledTrigger =
-  & BaseTrigger
-  & RequiredInputs
+type BaseTriggerSchedule = {
+  /** @description A date string of when this scheduled trigger should first occur */
+  start_time: string;
+  /**
+   *  @description A timezone string to use for scheduling
+   *  @default "UTC"
+   */
+  timezone?: string;
+};
+
+type SingleOccurrenceTriggerSchedule = BaseTriggerSchedule & {
+  frequency?: never;
+  end_time?: never;
+  occurence_count?: never;
+};
+
+type RecurringTriggerSchedule =
+  & BaseTriggerSchedule
   & {
-    type: typeof TriggerTypes.Scheduled;
-    schedule: {
-      /** @description A date string of when this scheduled trigger should first occur */
-      start_time: string;
-      /** @description If set, this trigger will not run past the provided date string  */
-      end_time?: string;
-      /**
-       *  @description A timezone string to use for scheduling
-       *  @default "UTC"
-       */
-      timezone?: string;
-      /** @description The maximum number of times the trigger may run */
-      occurence_count?: number;
-      /** @description The configurable frequency of which this trigger will activate  */
-      frequency?: FrequencyType;
-    };
+    /** @description If set, this trigger will not run past the provided date string  */
+    end_time?: string;
+    /** @description The maximum number of times the trigger may run */
+    occurence_count?: number;
+    /** @description The configurable frequency of which this trigger will activate  */
+    frequency: FrequencyType;
   };
+
+type TriggerSchedule =
+  | RecurringTriggerSchedule
+  | SingleOccurrenceTriggerSchedule;
+
+export type ScheduledTrigger = BaseTrigger & RequiredInputs & {
+  type: typeof TriggerTypes.Scheduled;
+  schedule: TriggerSchedule;
+};

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -17,13 +17,15 @@ const WEEKDAYS = {
   Sunday: "Sunday",
 } as const;
 
-type Frequency = typeof SCHEDULE_FREQUENCY[keyof typeof SCHEDULE_FREQUENCY];
+type FrequencyUnion =
+  typeof SCHEDULE_FREQUENCY[keyof typeof SCHEDULE_FREQUENCY];
+type WeekdayUnion = typeof WEEKDAYS[keyof typeof WEEKDAYS];
 
 type BaseFrequencyType = {
   /** @description How often the trigger will activate */
-  type: Frequency;
+  type: FrequencyUnion;
   /** @description The days of the week the trigger should activate on (not available for daily triggers) */
-  on_days?: (typeof WEEKDAYS[keyof typeof WEEKDAYS])[];
+  on_days?: WeekdayUnion[];
   /** @description How often the trigger will repeat, respective to the frequency type */
   repeats_every?: number;
   /**
@@ -44,18 +46,23 @@ type WeeklyFrequencyType = {
   type: typeof SCHEDULE_FREQUENCY.Weekly;
 } & Pick<BaseFrequencyType, "on_days" | "repeats_every">;
 
-type MonthlyOrYearlyFrequencyType = {
+type MonthlyFrequencyType = {
   /** @description How often the trigger will activate */
-  type: Extract<
-    Frequency,
-    typeof SCHEDULE_FREQUENCY.Monthly | typeof SCHEDULE_FREQUENCY.Yearly
-  >;
-} & Omit<BaseFrequencyType, "type">;
+  type: typeof SCHEDULE_FREQUENCY.Monthly;
+  /** @description The days of the week the trigger should activate on (not available for daily triggers) */
+  on_days?: [WeekdayUnion];
+} & Omit<BaseFrequencyType, "type" | "on_days">;
+
+type YearlyFrequencyType = {
+  /** @description How often the trigger will activate */
+  type: typeof SCHEDULE_FREQUENCY.Yearly;
+} & Pick<BaseFrequencyType, "repeats_every">;
 
 type FrequencyType =
   | DailyFrequencyType
   | WeeklyFrequencyType
-  | MonthlyOrYearlyFrequencyType;
+  | MonthlyFrequencyType
+  | YearlyFrequencyType;
 
 type BaseTriggerSchedule = {
   /** @description A date string of when this scheduled trigger should first occur */

--- a/src/typed-method-types/workflows/triggers/scheduled_test.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled_test.ts
@@ -1,0 +1,144 @@
+import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+import { ScheduledTrigger } from "./scheduled.ts";
+import { TriggerTypes } from "./mod.ts";
+
+Deno.test("Scheduled Triggers can be set with a string", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: "scheduled",
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set with TriggerTypes object", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set with just the start_time property", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set just once", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      timezone: "asia/kolkata",
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be recurring", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      end_time: "2022-05-01T14:00:00Z",
+      occurence_count: 3,
+      frequency: { type: "daily" },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be reoccur daily", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      frequency: {
+        type: "daily",
+        repeats_every: 3,
+      },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be reoccur weekly", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      frequency: {
+        type: "weekly",
+        repeats_every: 3,
+        on_days: ["Friday", "Monday"],
+      },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be reoccur monthly", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      frequency: {
+        type: "monthly",
+        repeats_every: 3,
+        on_days: ["Friday", "Monday"],
+        on_week_num: 1,
+      },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be reoccur yearly", () => {
+  const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      frequency: {
+        type: "yearly",
+        on_days: ["Friday", "Monday"],
+        on_week_num: 26,
+      },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});

--- a/src/typed-method-types/workflows/triggers/scheduled_test.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled_test.ts
@@ -117,7 +117,7 @@ Deno.test("Scheduled Triggers can be set to be reoccur monthly", () => {
       frequency: {
         type: "monthly",
         repeats_every: 3,
-        on_days: ["Friday", "Monday"],
+        on_days: ["Friday"],
         on_week_num: 1,
       },
     },
@@ -135,8 +135,7 @@ Deno.test("Scheduled Triggers can be set to be reoccur yearly", () => {
       start_time: "2022-03-01T14:00:00Z",
       frequency: {
         type: "yearly",
-        on_days: ["Friday", "Monday"],
-        on_week_num: 26,
+        repeats_every: 2,
       },
     },
   };

--- a/src/typed-method-types/workflows/triggers/webhook_test.ts
+++ b/src/typed-method-types/workflows/triggers/webhook_test.ts
@@ -22,7 +22,7 @@ Deno.test("Webhook Triggers can set the type using the TriggerTypes object", () 
   assertEquals(webhook.type, TriggerTypes.Webhook);
 });
 
-Deno.test("Webhook Trigger Filters support an optional webhook object", () => {
+Deno.test("Webhook Triggers support an optional filter object", () => {
   const webhook: WebhookTrigger = {
     type: TriggerTypes.Webhook,
     name: "test",


### PR DESCRIPTION
###  Summary

This PR adds strict typing based on these two focuses: 
- Separating Scheduled Triggers between a `SingleOccurrenceTriggerSchedule` and a `RecurringTriggerSchedule`
- Separating available frequencies into `DailyFrequencyType`, `WeeklyFrequencyType`, and `MonthlyOrYearlyFrequencyType`

#### Testing
In order to test this, point your app to this branch (locally or [the raw github url](https://raw.githubusercontent.com/slackapi/deno-slack-api/eef11fe/src/mod.ts)), instantiate your client within a runtime function definition and use client.workflows.triggers.create to create a Scheduled trigger.

Hopefully typeahead will guide you, but in case you need an example of a valid Scheduled trigger with frequency, here's one below:

```ts
await client.workflows.triggers.create({
    type: "scheduled",
    workflow: "example",
    inputs: {},
    name: "example",
    schedule: {
      start_time: "2022-03-01T14:00:00Z",
      frequency: {
        type: "daily",
        repeats_every: 2,
      },
    },
  });
```

### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
