### PR TITLE
added custom typing for list trigger

### DIFF
--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -15,6 +15,9 @@ export const methodsWithCustomTypes = [
   "apps.datastore.put",
   "apps.datastore.query",
   "workflows.triggers.create",
+  "workflows.triggers.update",
+  "workflows.triggers.delete",
+  "workflows.triggers.list",
 ];
 
 export type TypedSlackAPIMethodsType =

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -30,6 +30,10 @@ export type BaseTrigger = {
   description?: string;
 };
 
+export type TriggerIdType = {
+  trigger_id: string;
+};
+
 // A helper to make sure inputs are passed. Required for automated triggers
 export type RequiredInputs = Required<Pick<BaseTrigger, "inputs">>;
 
@@ -41,9 +45,22 @@ type ValidTriggerTypes =
 
 type BaseTriggerResponse = Promise<BaseResponse>;
 type TriggerResponse = BaseTriggerResponse;
+type ListArgs = {
+  is_owner?: boolean;
+  is_published?: boolean;
+};
 
 export type TypedWorkflowsTriggersMethodTypes = {
   create: (
     args: BaseMethodArgs & ValidTriggerTypes,
+  ) => TriggerResponse;
+  update: (
+    args: BaseMethodArgs & TriggerIdType & ValidTriggerTypes,
+  ) => TriggerResponse;
+  delete: (
+    args: BaseMethodArgs & TriggerIdType,
+  ) => TriggerResponse;
+  list: (
+    args?: BaseMethodArgs & ListArgs,
   ) => TriggerResponse;
 };


### PR DESCRIPTION
###  Summary

Added custom type for workflows.triggers.list

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
