### PR TITLE
Export the valid trigger types

### DIFF
--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -33,7 +33,7 @@ export type BaseTrigger = {
 // A helper to make sure inputs are passed. Required for automated triggers
 export type RequiredInputs = Required<Pick<BaseTrigger, "inputs">>;
 
-type ValidTriggerTypes =
+export type ValidTriggerTypes =
   | EventTrigger
   | ScheduledTrigger
   | ShortcutTrigger

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { TypedSlackAPIMethodsType } from "./typed-method-types/mod.ts";
 import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
 
+export type { ValidTriggerTypes } from "./typed-method-types/workflows/triggers/mod.ts";
+
 export type BaseResponse = {
   /** `true` if the response from the server was successful, `false` otherwise. */
   ok: boolean;


### PR DESCRIPTION
###  Summary

We want to export the type for our triggers so that it can be used in a trigger definition file.

#### Example
```ts
// trigger.ts file
import { ValidTriggerTypes } from "deno-slack-api/types.ts";

const trigger: ValidTriggerTypes = {
  "type": "shortcut",
  "name": "Simple trigger",
  "workflow": "Example",
  "inputs": {
    "example1": {
      "value": "some string",
    },
  },
};
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
