### PR TITLE
Improve the code line reference in a comment

### DIFF
--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -62,7 +62,7 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
   Object.entries(data).forEach(([key, value]) => {
     // Objects/arrays, numbers and booleans get stringified
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
-    // Inspired by https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L452
+    // Inspired by https://github.com/slackapi/node-slack-sdk/blob/%40slack/web-api%406.7.2/packages/web-api/src/WebClient.ts#L452-L528
 
     const serializedValue: string =
       (typeof value !== "string" ? JSON.stringify(value) : value);


### PR DESCRIPTION
###  Summary

This pull request improves the internal code comment to be more robust. The referenced code line number in the main branch can be different in the future.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
