### PR TITLE
Deprecate ValidTriggerTypes export and use Trigger instead

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,13 @@
 import { TypedSlackAPIMethodsType } from "./typed-method-types/mod.ts";
 import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
 
-export type { ValidTriggerTypes } from "./typed-method-types/workflows/triggers/mod.ts";
+export type {
+  /**
+   * @deprecated Use Trigger instead
+   */
+  ValidTriggerTypes,
+  ValidTriggerTypes as Trigger,
+} from "./typed-method-types/workflows/triggers/mod.ts";
 
 export type BaseResponse = {
   /** `true` if the response from the server was successful, `false` otherwise. */


### PR DESCRIPTION
###  Summary

Deprecate ValidTriggerTypes export and use Trigger instead
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
