### PR TITLE
Fix typo in scheduled triggers definition: occurence -> occurrence

### DIFF
--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -81,7 +81,7 @@ type BaseTriggerSchedule = {
 type SingleOccurrenceTriggerSchedule = BaseTriggerSchedule & {
   frequency?: never;
   end_time?: never;
-  occurence_count?: never;
+  occurrence_count?: never;
 };
 
 type RecurringTriggerSchedule =
@@ -90,7 +90,7 @@ type RecurringTriggerSchedule =
     /** @description If set, this trigger will not run past the provided date string  */
     end_time?: string;
     /** @description The maximum number of times the trigger may run */
-    occurence_count?: number;
+    occurrence_count?: number;
     /** @description The configurable frequency of which this trigger will activate  */
     frequency: FrequencyType;
   };

--- a/src/typed-method-types/workflows/triggers/scheduled_test.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled_test.ts
@@ -64,7 +64,7 @@ Deno.test("Scheduled Triggers can be set to be recurring", () => {
     schedule: {
       start_time: "2022-03-01T14:00:00Z",
       end_time: "2022-05-01T14:00:00Z",
-      occurence_count: 3,
+      occurrence_count: 3,
       frequency: { type: "daily" },
     },
   };


### PR DESCRIPTION
###  Summary

Fix a spelling error in scheduled triggers definition

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
