### PR TITLE
Add introductory typing to chat.postMessage functions.completeError and functions.completeSuccess

### DIFF
--- a/src/api-proxy_test.ts
+++ b/src/api-proxy_test.ts
@@ -17,7 +17,7 @@ Deno.test("APIProxy", async () => {
 
   const client = APIProxy(clientToProxy, apiCallHandlerSpy);
 
-  const payload = { text: "proxied call" };
+  const payload = { text: "proxied call", channel: "" };
   await client.chat.postMessage(payload);
 
   assertSpyCall(apiCallHandlerSpy, 0, {

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -147,7 +147,7 @@ Deno.test("SlackAPI class", async (t) => {
           return new Response('{"ok":true}');
         });
 
-        const res = await client.chat.postMessage({});
+        const res = await client.chat.postMessage({ channel: "", text: "" });
         assertEquals(res.ok, true);
 
         mf.reset();

--- a/src/generated/method-types/api_method_types_test.ts
+++ b/src/generated/method-types/api_method_types_test.ts
@@ -144,7 +144,6 @@ Deno.test("SlackAPIMethodsType generated types", () => {
   assertEquals(typeof client.chat.getPermalink, "function");
   assertEquals(typeof client.chat.meMessage, "function");
   assertEquals(typeof client.chat.postEphemeral, "function");
-  assertEquals(typeof client.chat.postMessage, "function");
   assertEquals(typeof client.chat.scheduledMessages.list, "function");
   assertEquals(typeof client.chat.scheduleMessage, "function");
   assertEquals(typeof client.chat.unfurl, "function");
@@ -197,8 +196,6 @@ Deno.test("SlackAPIMethodsType generated types", () => {
   assertEquals(typeof client.files.revokePublicURL, "function");
   assertEquals(typeof client.files.sharedPublicURL, "function");
   assertEquals(typeof client.files.upload, "function");
-  assertEquals(typeof client.functions.completeError, "function");
-  assertEquals(typeof client.functions.completeSuccess, "function");
   assertEquals(typeof client.migration.exchange, "function");
   assertEquals(typeof client.oauth.access, "function");
   assertEquals(typeof client.oauth.v2.access, "function");

--- a/src/generated/method-types/chat.ts
+++ b/src/generated/method-types/chat.ts
@@ -6,7 +6,6 @@ export type ChatAPIType = {
   getPermalink: SlackAPIMethod;
   meMessage: SlackAPIMethod;
   postEphemeral: SlackAPIMethod;
-  postMessage: SlackAPIMethod;
   scheduledMessages: {
     list: SlackAPIMethod;
   };

--- a/src/generated/method-types/functions.ts
+++ b/src/generated/method-types/functions.ts
@@ -1,6 +1,0 @@
-import { SlackAPIMethod } from "../../types.ts";
-
-export type FunctionsAPIType = {
-  completeError: SlackAPIMethod;
-  completeSuccess: SlackAPIMethod;
-};

--- a/src/generated/method-types/mod.ts
+++ b/src/generated/method-types/mod.ts
@@ -12,7 +12,6 @@ import { type DndAPIType } from "./dnd.ts";
 import { type EmojiAPIType } from "./emoji.ts";
 import { type EnterpriseAPIType } from "./enterprise.ts";
 import { type FilesAPIType } from "./files.ts";
-import { type FunctionsAPIType } from "./functions.ts";
 import { type MigrationAPIType } from "./migration.ts";
 import { type OauthAPIType } from "./oauth.ts";
 import { type OpenidAPIType } from "./openid.ts";
@@ -44,7 +43,6 @@ export type SlackAPIMethodsType = {
   emoji: EmojiAPIType;
   enterprise: EnterpriseAPIType;
   files: FilesAPIType;
-  functions: FunctionsAPIType;
   migration: MigrationAPIType;
   oauth: OauthAPIType;
   openid: OpenidAPIType;

--- a/src/typed-method-types/chat.ts
+++ b/src/typed-method-types/chat.ts
@@ -1,11 +1,15 @@
 import { BaseResponse } from "../types.ts";
 
 type ChatPostMessageOptionalArgs = {
+  /** @description The formatted text of the message to be published. If blocks are included, this will become the fallback text used in notifications. */
   text?: string;
+  /** @description A JSON-based array of structured attachments. */
   // deno-lint-ignore no-explicit-any
   attachments?: any[];
+  /** @description A JSON-based array of structured blocks. */
   // deno-lint-ignore no-explicit-any
   blocks?: any[];
+  /** @description Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead. */
   thread_ts?: string;
   // deno-lint-ignore no-explicit-any
   [otherOptions: string]: any;
@@ -20,6 +24,7 @@ type ChatPostMessageOneOfRequired =
   >;
 
 type ChatPostMessageArgs = ChatPostMessageOneOfRequired & {
+  /** @description Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name. */
   channel: string;
 };
 

--- a/src/typed-method-types/chat.ts
+++ b/src/typed-method-types/chat.ts
@@ -1,0 +1,34 @@
+import { BaseResponse } from "../types.ts";
+
+type ChatPostMessageOptionalArgs = {
+  text?: string;
+  // deno-lint-ignore no-explicit-any
+  attachments?: any[];
+  // deno-lint-ignore no-explicit-any
+  blocks?: any[];
+  thread_ts?: string;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type ChatPostMessageOneOfRequired =
+  & ChatPostMessageOptionalArgs
+  & Required<
+    | Pick<ChatPostMessageOptionalArgs, "text">
+    | Pick<ChatPostMessageOptionalArgs, "blocks">
+    | Pick<ChatPostMessageOptionalArgs, "attachments">
+  >;
+
+type ChatPostMessageArgs = ChatPostMessageOneOfRequired & {
+  channel: string;
+};
+
+type ChatPostMessage = {
+  (args: ChatPostMessageArgs): Promise<BaseResponse>;
+};
+
+export type TypedChatMethodTypes = {
+  chat: {
+    postMessage: ChatPostMessage;
+  };
+};

--- a/src/typed-method-types/functions.ts
+++ b/src/typed-method-types/functions.ts
@@ -1,0 +1,31 @@
+import { BaseResponse } from "../types.ts";
+
+type FunctionCompleteSuccessArgs = {
+  // deno-lint-ignore no-explicit-any
+  outputs: Record<string, any>;
+  function_execution_id: string;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type FunctionCompleteErrorArgs = {
+  error: string;
+  function_execution_id: string;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type FunctionCompleteError = {
+  (args: FunctionCompleteErrorArgs): Promise<BaseResponse>;
+};
+
+type FunctionCompleteSuccess = {
+  (args: FunctionCompleteSuccessArgs): Promise<BaseResponse>;
+};
+
+export type TypedFunctionMethodTypes = {
+  functions: {
+    completeError: FunctionCompleteError;
+    completeSuccess: FunctionCompleteSuccess;
+  };
+};

--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -3,6 +3,8 @@
  * It is meant to be additive to the SlackClient type
  */
 import { TypedAppsMethodTypes } from "./apps.ts";
+import { TypedChatMethodTypes } from "./chat.ts";
+import { TypedFunctionMethodTypes } from "./functions.ts";
 import { TypedWorkflowsMethodTypes } from "./workflows/mod.ts";
 
 /**
@@ -14,6 +16,9 @@ export const methodsWithCustomTypes = [
   "apps.datastore.get",
   "apps.datastore.put",
   "apps.datastore.query",
+  "chat.postMessage",
+  "functions.completeSuccess",
+  "functions.completeError",
   "workflows.triggers.create",
   "workflows.triggers.list",
   "workflows.triggers.update",
@@ -22,4 +27,6 @@ export const methodsWithCustomTypes = [
 
 export type TypedSlackAPIMethodsType =
   & TypedAppsMethodTypes
+  & TypedChatMethodTypes
+  & TypedFunctionMethodTypes
   & TypedWorkflowsMethodTypes;


### PR DESCRIPTION
###  Summary

Add the following methods to our list of custom typing:
- `chat.postMessage`
- `functions.completeError`
- `functions.completeSuccess`

### Testing
Instantiate your `client` within a function and try to use the following methods. They should now provide type-ahead!

### Code Examples
```ts
const client = SlackAPI(token);
    await client.chat.postMessage({
      channel: "",
      text: "",
      // attachments: [],
      // blocks: [],
    });

    await client.functions.completeSuccess({
      function_execution_id: "",
      outputs: {},
    });

    await client.functions.completeError({
      error: "",
      function_execution_id: ""
    })
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
