### PR TITLE
Add a response type for chat.postMessage

### DIFF
--- a/src/typed-method-types/chat.ts
+++ b/src/typed-method-types/chat.ts
@@ -28,8 +28,30 @@ type ChatPostMessageArgs = ChatPostMessageOneOfRequired & {
   channel: string;
 };
 
+type ChatPostMessageSuccessfulResponse = BaseResponse & {
+  ok: true;
+  /** @description The channel the message was posted to */
+  channel: string;
+  /** @description The timestamp of when the message was posted */
+  ts: string;
+  // deno-lint-ignore no-explicit-any
+  message: Record<string, any>;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type ChatPostMessageFailedResponse = BaseResponse & {
+  ok: false;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type ChatPostMessageResponse =
+  | ChatPostMessageSuccessfulResponse
+  | ChatPostMessageFailedResponse;
+
 type ChatPostMessage = {
-  (args: ChatPostMessageArgs): Promise<BaseResponse>;
+  (args: ChatPostMessageArgs): Promise<ChatPostMessageResponse>;
 };
 
 export type TypedChatMethodTypes = {


### PR DESCRIPTION
###  Summary
This adds response typing for `chat.postMessage`

### Testing

Assign the result of a `chat.postMessage` call to a variable and see what you can access! Compare that to the response logged to the console.
_This is not intended to include all properties from the response, just the important ones_

```ts
const response = await client.chat.postMessage({});
response.ts;
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
