### PR TITLE
adding setSlackApiUrl() to BaseClient

### DIFF
--- a/src/api-proxy.ts
+++ b/src/api-proxy.ts
@@ -13,6 +13,7 @@ export const ProxifyAndTypeClient = (baseClient: BaseSlackAPIClient) => {
 
   // Create a subset of the client that we want to wrap our Proxy() around
   const clientToProxy = {
+    setSlackApiUrl: baseClient.setSlackApiUrl.bind(baseClient),
     apiCall: baseClient.apiCall.bind(baseClient),
     response: baseClient.response.bind(baseClient),
   };

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -138,6 +138,28 @@ Deno.test("SlackAPI class", async (t) => {
     });
   });
 
+  await t.step(
+    "instantiated with custom API URL without trailing slash",
+    async (t) => {
+      const client = SlackAPI("test-token", {
+        slackApiUrl: "https://apitown.com",
+      });
+
+      await t.step("apiCall method", async (t) => {
+        await t.step("should call the custom API URL", async () => {
+          mf.mock("POST@/chat.postMessage", (req: Request) => {
+            assertEquals(req.url, "https://apitown.com/chat.postMessage");
+            return new Response('{"ok":true}');
+          });
+
+          await client.apiCall("chat.postMessage", {});
+
+          mf.reset();
+        });
+      });
+    },
+  );
+
   await t.step("calling custom method accessor functions", async (t) => {
     const client = SlackAPI("test-token");
 
@@ -230,6 +252,22 @@ Deno.test("SlackApi.setSlackApiUrl()", async (t) => {
 
   await t.step("override url", async () => {
     testClient.setSlackApiUrl("https://something.slack.com/api/");
+
+    mf.mock("POST@/api/chat.postMessage", (req: Request) => {
+      assertEquals(
+        req.url,
+        "https://something.slack.com/api/chat.postMessage",
+      );
+      return new Response('{"ok":true}');
+    });
+
+    await testClient.apiCall("chat.postMessage", {});
+
+    mf.reset();
+  });
+
+  await t.step("override url without trailing slash", async () => {
+    testClient.setSlackApiUrl("https://something.slack.com/api");
 
     mf.mock("POST@/api/chat.postMessage", (req: Request) => {
       assertEquals(

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -14,6 +14,12 @@ export class BaseSlackAPIClient implements BaseSlackClient {
     this.#baseURL = options.slackApiUrl || "https://slack.com/api/";
   }
 
+  setSlackApiUrl(apiURL: string) {
+    this.#baseURL = apiURL;
+
+    return this;
+  }
+
   async apiCall(
     method: string,
     data: SlackAPIMethodArgs = {},

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -14,6 +14,12 @@ export class BaseSlackAPIClient implements BaseSlackClient {
     this.#baseURL = options.slackApiUrl || "https://slack.com/api/";
   }
 
+  /**
+   * @description Set an override url endpoint for Slack API calls.
+   * @param apiURL url endpoint for the Slack API used for api calls. It should include the protocol, the domain and the path.
+   * @example: "https://slack.com/api/"
+   * @returns BaseSlackClient
+   */
   setSlackApiUrl(apiURL: string) {
     this.#baseURL = apiURL;
 
@@ -24,7 +30,8 @@ export class BaseSlackAPIClient implements BaseSlackClient {
     method: string,
     data: SlackAPIMethodArgs = {},
   ): Promise<BaseResponse> {
-    const url = `${this.#baseURL}${method}`;
+    // ensure there's a slash prior to method
+    const url = `${this.#baseURL.replace(/\/$/, "")}/${method}`;
     const body = serializeData(data);
 
     const token = data.token || this.#token || "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type SlackAPIClient =
   & SlackAPIMethodsType;
 
 export type BaseSlackClient = {
+  setSlackApiUrl: (slackApiUrl: string) => BaseSlackClient;
   apiCall: BaseClientCall;
   response: BaseClientResponse;
 };


### PR DESCRIPTION
###  Summary

Adds a `setSlackApiUrl()` function to the `BaseClient` class. This is to enable being able to change the `slackApiUrl` value after instantiating a client. This will primarily be helpful in allowing us to provide an instance of the api client in the SDK as a handler param, while still allowing the ability to point the client to a non-default api url.

```ts
const client = SlackApi();

// uses default slack api url of `https://slack.com/api/`
client.apiCall()

client.setSlackApiUrl("https://something.slack.com/api/");

// uses `https://something.slack.com/api/`
client.apiCall();
```

## Testing
I've added a unit test. This can also be be manually tested by importing this version directly via:

```ts
import { SlackAPI } from "https://raw.githubusercontent.com/slackapi/deno-slack-api/4b8939ead52974351ed15fbd430c9b82265e377c/src/mod.ts";
```

and then somewhere in a function handler where you might have it use the `SLACK_API_URL` already, update it to be:

```ts
const client = SlackAPI();

if (env.SLACK_API_URL) {
  client.setSlackApiUrl(env.SLACK_API_URL);
}
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
