### PR TITLE
Trigger workflow input usage docs

### DIFF
--- a/docs/triggers/event-triggers.md
+++ b/docs/triggers/event-triggers.md
@@ -314,7 +314,7 @@ The `inputs` parameter has access to context information from when the Trigger i
       "date_created": 1626789600    
     }  
   ],  
-  "accepting_user": {    // Standard hermes user object    
+  "accepting_user": {    // Standard user object    
     "id": "U123",    
     "team_id": "T123",    
     "name": "John Doe",    
@@ -468,7 +468,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 ## Usage
-The examples below are sample Trigger objects which can be used to create Triggers in the [CLI](./trigger-basics.md/#creating-triggers-using-the-hermes-cli).
+The examples below are sample Trigger objects which can be used to create Triggers in the [CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli).
 ### Channel Level Trigger
 ```ts
 const trigger: Trigger = {

--- a/docs/triggers/link-triggers.md
+++ b/docs/triggers/link-triggers.md
@@ -44,7 +44,7 @@ The data context can be used in the input parameter as follows:
 }
 ```
 ## Usage
-Below are some usage examples of `ShortcutTrigger` objects which can be used in a .ts file to create a `shortcut` trigger through the [Hermes CLI](./trigger-basics.md/#creating-triggers-using-the-hermes-cli), alternatively this object could be passed into a 
+Below are some usage examples of `ShortcutTrigger` objects which can be used in a .ts file to create a `shortcut` trigger through the [Slack CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli), alternatively this object could be passed into a 
 `client.workflows.triggers.create` method to achieve the same effect at [runtime](./trigger-basics.md/#creating-triggers-in-the-runtime-environment).
 
 ### Example Configured Shortcut Trigger

--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -55,7 +55,7 @@ The data context can be used in the input parameter as follows:
 
 ## Usage
 
-Below are some usage examples of `ScheduledTrigger` objects which can be used in a .ts file to create a `scheduled` Trigger through the Hermes CLI, alternatively this object could be passed into a 
+Below are some usage examples of `ScheduledTrigger` objects which can be used in a .ts file to create a `scheduled` Trigger through the Slack CLI, alternatively this object could be passed into a 
 `client.workflows.triggers.create` method to achieve the same effect at runtime.
 
 ### Single Occurrence Schedule

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -25,6 +25,11 @@ Each Trigger type has access to a `data` context object which includes informati
 ## Creating Triggers
 
 Triggers can be created in one of two ways, either dynamically in your application at runtime, or through the Hermes CLI. More details on Trigger creation can be found in the [API documentation](https://api.dev.slack.com/future/triggers#create).
+
+### Creating Triggers Generic Inputs
+
+Triggers can be created or updated at runtime with an optional `WorkflowDefinition` as a generic input which utilizes the `WorkflowDefinition` object defined in the manifest to help specify what `inputs` a Trigger will require. Additional details can be found [here](trigger-generic-inputs.md).
+
 ### Creating Triggers using the Hermes CLI
 
 To create a Trigger using the Hermes CLI, create a file that contains your Trigger TypeScript format. Run the `trigger create` command with a `--trigger-def` flag pointing to your desired trigger file.
@@ -35,6 +40,27 @@ slack trigger create --trigger-def "path/to/trigger.ts"
 
 Example trigger objects in valid typescript and JSON formats can be viewed below.
 
+#### With Generic Input
+```ts
+import { Trigger } from "deno-slack-api/types.ts";
+import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
+
+const trigger: Trigger<typeof TriggersWorkflow.definition> = {
+  type: "shortcut", // the type of Trigger
+  name: "Request Time off", // the name of the Trigger
+  description: "Starts the workflow to request time off", //Trigger description
+  workflow: "#/workflows/reverse_workflow", //the workflow your Trigger activates
+  inputs: { //Trigger inputs
+    interactivity: {
+      value: "{{data.interactivity}}",
+    },
+  },
+};
+
+export default trigger;
+```
+
+#### Without Generic Input
 ```ts
 import { Trigger } from "deno-slack-api/types.ts";
 
@@ -58,6 +84,27 @@ export default trigger;
 Creating Triggers at runtime from within your application utilizes the `SlackAPI` client to make an API call to the Slack API.
 Creation uses the `client.workflows.triggers.create` method which takes in a Trigger object as input. 
 
+#### With Generic Input
+```ts
+  import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
+
+  const client = SlackAPI(token);
+
+  const shortcutResponse = await client.workflows.triggers.create<typeof TriggersWorkflow.definition>({
+    type: "shortcut",
+    name: "Request Time off",
+    description: "Starts the workflow to request time off",
+    workflow: "#/workflows/reverse_workflow",
+    inputs: {
+      interactivity: {
+        value: "{{data.interactivity}}",
+      },
+    },
+  });
+```
+
+#### Without Generic Input
+
 ```ts
   const client = SlackAPI(token);
 
@@ -73,14 +120,13 @@ Creation uses the `client.workflows.triggers.create` method which takes in a Tri
     },
   });
 ```
-
 ## Updating Triggers
 
 Similar to creating, updating Triggers can be done through the CLI, or at runtime using the `client.workflows.triggers.update` method. Updating a Trigger takes the same Trigger object as creating one, with the addition of a `trigger_id` parameter to identify the Trigger being updated. More details on updating Triggers can be found in the [API documentation](https://api.dev.slack.com/future/triggers#update).
 
 ### Updating Triggers in the CLI
 
-To update a Trigger using the Hermes CLI, make the desired update to your existing Trigger file. When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
+To update a Trigger using the Hermes CLI, make the desired update to your existing [Trigger File](#creating-triggers-using-the-hermes-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
 
 ```
 slack trigger update --trigger-id Ft123ABC --trigger-def "path/to/trigger.ts"
@@ -90,10 +136,12 @@ slack trigger update --trigger-id Ft123ABC --trigger-def "path/to/trigger.ts"
 
 Updating uses the `client.workflows.triggers.update` method which takes in the same Trigger object as the create call as input, with the addition of a `trigger_id` parameter. 
 
+#### With Generic Input
 ```ts
+  import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
   const client = SlackAPI(token);
 
-  const shortcutResponse = await client.workflows.triggers.create({
+  const shortcutResponse = await client.workflows.triggers.update<typeof TriggersWorkflow.definition>({
     trigger_id: "FtABC123",
     type: "shortcut",
     name: "Request Time off",
@@ -107,6 +155,24 @@ Updating uses the `client.workflows.triggers.update` method which takes in the s
   });
 ```
 
+#### Without Generic Input
+```ts
+  import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
+  const client = SlackAPI(token);
+
+  const shortcutResponse = await client.workflows.triggers.update({
+    trigger_id: "FtABC123",
+    type: "shortcut",
+    name: "Request Time off",
+    description: "Starts the workflow to request time off",
+    workflow: "#/workflows/reverse_workflow",
+    inputs: {
+      interactivity: {
+        value: "{{data.interactivity}}",
+      },
+    },
+  });
+```
 ## Deleting Triggers 
 
 Triggers can be deleted by passing the Trigger ID. See the [API documentation](https://api.dev.slack.com/future/triggers#delete) for more details.

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -24,21 +24,21 @@ Each Trigger type has access to a `data` context object which includes informati
 
 ## Creating Triggers
 
-Triggers can be created in one of two ways, either dynamically in your application at runtime, or through the Hermes CLI. More details on Trigger creation can be found in the [API documentation](https://api.dev.slack.com/future/triggers#create).
+Triggers can be created in one of two ways, either dynamically in your application at runtime, or through the Slack CLI. More details on Trigger creation can be found in the [API documentation](https://api.dev.slack.com/future/triggers#create).
 
 ### Creating Triggers Generic Inputs
 
 Triggers can be created or updated at runtime with an optional `WorkflowDefinition` as a generic input which utilizes the `WorkflowDefinition` object defined in the manifest to help specify what `inputs` a Trigger will require. Additional details can be found [here](trigger-generic-inputs.md).
 
-### Creating Triggers using the Hermes CLI
+### Creating Triggers using the Slack CLI
 
-To create a Trigger using the Hermes CLI, create a file that contains your Trigger TypeScript format. Run the `trigger create` command with a `--trigger-def` flag pointing to your desired trigger file.
+To create a Trigger using the Slack CLI, create a file that contains your Trigger TypeScript format. Run the `trigger create` command with a `--trigger-def` flag pointing to your desired trigger file.
 
 ```
 slack trigger create --trigger-def "path/to/trigger.ts"
 ```
 
-Example trigger objects in valid typescript and JSON formats can be viewed below.
+Example `trigger` objects in valid typescript and JSON formats can be viewed below. With a Generic Input these `trigger` objects will have access to typeahead for valid input parameters.
 
 #### With Generic Input
 ```ts
@@ -126,7 +126,7 @@ Similar to creating, updating Triggers can be done through the CLI, or at runtim
 
 ### Updating Triggers in the CLI
 
-To update a Trigger using the Hermes CLI, make the desired update to your existing [Trigger File](#creating-triggers-using-the-hermes-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
+To update a Trigger using the Slack CLI, make the desired update to your existing [Trigger File](#creating-triggers-using-the-slack-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
 
 ```
 slack trigger update --trigger-id Ft123ABC --trigger-def "path/to/trigger.ts"

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -1,52 +1,28 @@
-# Trigger Creation Workflow Definition Inputs
+# Trigger Generics
 
-When creating a trigger at runtime, a workflow definition can be passed into the `client.workflows.triggers.create` method which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
+When creating or updating a trigger at runtime, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
 
-## Defining A Workflow Recap
+## Defining A Workflow
 
-Recall in the `manifest.ts` file of an app, a `workflow` can be defined using the `DefineWorkflow` method as follows:
-
-```ts
-export const TriggersWorkflow = DefineWorkflow({
-  callback_id: "triggers_workflow",
-  title: "Triggers Workflow",
-  description: "sample runthrough of a trigger creation",
-  input_parameters: {
-    properties: {
-      a_string: {
-        type: Schema.types.string,
-      },
-      b_string: {
-        type: Schema.types.string,
-      },
-      a_channel: {
-        type: Schema.slack.types.channel_id,
-      },
-    },
-    required: [],
-  },
-});
-```
-
+Recall that in the [SDK](https://github.com/slackapi/deno-slack-sdk/blob/main/docs/workflows.md#workflows), a `workflow` can be defined using the `DefineWorkflow` method.
 When a workflow is created in this manner, if contains a `workflow.definition` object. By passing this definition into the `create` method, the trigger will have access to information related to the workflow's definition.
 
-### Using Workflow definition input at runtime Example 
+### Using Trigger Generics at runtime Example 
 
 ```ts
-import type { SlackFunctionHandler } from "../../deno-slack-sdk/src/types.ts";
+import type { SlackFunction } from "/deno-slack-sdk/src/types.ts";
 import { TriggersFunction, TriggersWorkflow } from "../manifest.ts";
 import { SlackAPI } from "../../deno-slack-api/src/mod.ts";
 
-const triggers: SlackFunctionHandler<typeof TriggersFunction.definition> = 
+const triggers: SlackFunction<typeof TriggersFunction.definition> = 
   async (
     { token, env },
   ) => {
     const client = SlackAPI(token, {
       slackApiUrl: env["SLACK_API_URL"],
     });
-    const workflowDef = TriggersWorkflow.definition;
-    const triggerResponse = await client.workflows.triggers.create<
-      typeof workflowDef //Definition passed in as a generic
+    const triggerResponse = await client.workflows.triggers.create< 
+      typeof TriggersWorkflow.definition //The same generic can be passed into the update method
     >({
       type: "webhook",
       name: "Request Time off",
@@ -58,9 +34,9 @@ const triggers: SlackFunctionHandler<typeof TriggersFunction.definition> =
 
 ## Workflow Definition Input with CLI Triggers
 
-A `workflow` definition input can also be passed to the `trigger` file that is used to create a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` method.
+A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` or `update` method.
 
-### Using Workflow definition input with CLI Example
+### Using Trigger Generics with CLI Example
 
 ```ts
 import { Trigger } from "../deno-slack-api/src/types.ts";

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -17,7 +17,6 @@ When dealing with Triggers at runtime, a Workflow definition input can optionall
 import { TriggersWorkflow } from "../manifest.ts";
 import { SlackAPI } from "deno-slack-api/mod.ts";
 
-...
 {
   //Inside the function execution logic
   const client = SlackAPI(token);
@@ -41,7 +40,7 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
       },
     },
 }
-
+```
 ## Workflow Definition Input with CLI Triggers
 
 A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -5,36 +5,35 @@ When creating or updating a trigger at runtime, a Workflow definition can be pas
 ## Defining A Workflow
 
 Recall that in the [SDK](https://github.com/slackapi/deno-slack-sdk/blob/main/docs/workflows.md#workflows), a `workflow` can be defined using the `DefineWorkflow` method.
-When a workflow is created in this manner, it contains a `workflow.definition` object. By passing this definition into the `create` method, the trigger will have access to information related to the workflow's definition.
+When a workflow is created in this manner, it contains a `workflow.definition` object. By passing this definition into the `create` or `update` method, the trigger will have access to information related to the workflow's definition.
 
 ### Using Trigger Generics at runtime Example 
 
 ```ts
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
-import { TriggersFunction, TriggersWorkflow } from "../manifest.ts";
+import { TriggersWorkflow } from "../manifest.ts";
 import { SlackAPI } from "deno-slack-api/mod.ts";
 
-const triggers: SlackFunction<typeof TriggersFunction.definition> = 
-  async (
-    { token, env },
-  ) => {
-    const client = SlackAPI(token, {
-      slackApiUrl: env["SLACK_API_URL"],
-    });
-    const triggerResponse = await client.workflows.triggers.create< 
-      typeof TriggersWorkflow.definition //The same generic can be passed into the update method
-    >({
-      type: "webhook",
-      name: "Request Time off",
-      description: "Starts the workflow to request time off",
-      workflow: "#/workflows/reverse_workflow",
-      inputs: {
-        a_input: {
-          value: "test_value",
-        }
-      }
-    });
-  }
+const client = SlackAPI(token);
+
+const triggerReturn = await client.workflows.triggers.create<
+  typeof TriggersWorkflow.definition
+>({
+  type: "webhook",
+  name: "Request Time off",
+  description: "Starts the workflow to request time off",
+  workflow: "#/workflows/reverse_workflow",
+  inputs: {
+    a_string: {
+      value: "TEST",
+    },
+    a_channel: {
+      value: "TEST",
+    },
+    b_string: {
+      value: "TEST",
+    },
+  },
+});
 ```
 
 ## Workflow Definition Input with CLI Triggers

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -7,34 +7,40 @@ When creating or updating a trigger at runtime, a Workflow definition can be pas
 Recall that in the [SDK](https://github.com/slackapi/deno-slack-sdk/blob/main/docs/workflows.md#workflows), a `workflow` can be defined using the `DefineWorkflow` method.
 When a workflow is created in this manner, it contains a `workflow.definition` object. By passing this definition into the `create` or `update` method, the trigger will have access to information related to the workflow's definition.
 
+## Workflow Definition Input with Runtime Triggers
+
+When dealing with Triggers at runtime, a Workflow definition input can optionally be passed to the Trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
+
 ### Using Trigger Generics at runtime Example 
 
 ```ts
 import { TriggersWorkflow } from "../manifest.ts";
 import { SlackAPI } from "deno-slack-api/mod.ts";
 
-const client = SlackAPI(token);
-
-const triggerReturn = await client.workflows.triggers.create< //Also works for update
-  typeof TriggersWorkflow.definition
->({
-  type: "webhook",
-  name: "Request Time off",
-  description: "Starts the workflow to request time off",
-  workflow: "#/workflows/reverse_workflow",
-  inputs: { //inputs can now be autofilled from the Workflow Definition
-    a_string: {
-      value: "TEST",
+...
+{
+  //Inside the function execution logic
+  const client = SlackAPI(token);
+  
+  const triggerReturn = await client.workflows.triggers.create< //Also works for update
+    typeof TriggersWorkflow.definition
+  >({
+    type: "webhook",
+    name: "Request Time off",
+    description: "Starts the workflow to request time off",
+    workflow: "#/workflows/reverse_workflow",
+    inputs: { //inputs can now be autofilled from the Workflow Definition
+      a_string: {
+        value: "TEST",
+      },
+      a_channel: {
+        value: "TEST",
+      },
+      b_string: {
+        value: "TEST",
+      },
     },
-    a_channel: {
-      value: "TEST",
-    },
-    b_string: {
-      value: "TEST",
-    },
-  },
-});
-```
+}
 
 ## Workflow Definition Input with CLI Triggers
 

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -1,0 +1,80 @@
+# Trigger Creation Workflow Definition Inputs
+
+When creating a trigger at runtime, a workflow definition can be passed into the `client.workflows.triggers.create` method which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
+
+## Defining A Workflow Recap
+
+Recall in the `manifest.ts` file of an app, a `workflow` can be defined using the `DefineWorkflow` method as follows:
+
+```ts
+export const TriggersWorkflow = DefineWorkflow({
+  callback_id: "triggers_workflow",
+  title: "Triggers Workflow",
+  description: "sample runthrough of a trigger creation",
+  input_parameters: {
+    properties: {
+      a_string: {
+        type: Schema.types.string,
+      },
+      b_string: {
+        type: Schema.types.string,
+      },
+      a_channel: {
+        type: Schema.slack.types.channel_id,
+      },
+    },
+    required: [],
+  },
+});
+```
+
+When a workflow is created in this manner, if contains a `workflow.definition` object. By passing this definition into the `create` method, the trigger will have access to information related to the workflow's definition.
+
+### Using Workflow definition input at runtime Example 
+
+```ts
+import type { SlackFunctionHandler } from "../../deno-slack-sdk/src/types.ts";
+import { TriggersFunction, TriggersWorkflow } from "../manifest.ts";
+import { SlackAPI } from "../../deno-slack-api/src/mod.ts";
+
+const triggers: SlackFunctionHandler<typeof TriggersFunction.definition> = 
+  async (
+    { token, env },
+  ) => {
+    const client = SlackAPI(token, {
+      slackApiUrl: env["SLACK_API_URL"],
+    });
+    const workflowDef = TriggersWorkflow.definition;
+    const triggerResponse = await client.workflows.triggers.create<
+      typeof workflowDef //Definition passed in as a generic
+    >({
+      type: "webhook",
+      name: "Request Time off",
+      description: "Starts the workflow to request time off",
+      workflow: "#/workflows/reverse_workflow",
+    });
+  }
+```
+
+## Workflow Definition Input with CLI Triggers
+
+A `workflow` definition input can also be passed to the `trigger` file that is used to create a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` method.
+
+### Using Workflow definition input with CLI Example
+
+```ts
+import { Trigger } from "../deno-slack-api/src/types.ts";
+import { TriggersWorkflow } from "./manifest.ts";
+
+const trigger: Trigger<typeof TriggersWorkflow.definition> = { //Workflow definition is passed to the trigger object
+  type: "shortcut",
+  name: "Get Triggers List",
+  description: "Starts the workflow to request time off",
+  workflow: "#/workflows/list_trigger_workflow",
+  inputs: {    //The inputs parameter will now have typeahead based on the Workflow definition being passed in.
+    
+  }
+};
+
+export default trigger;
+```

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -5,14 +5,14 @@ When creating or updating a trigger at runtime, a Workflow definition can be pas
 ## Defining A Workflow
 
 Recall that in the [SDK](https://github.com/slackapi/deno-slack-sdk/blob/main/docs/workflows.md#workflows), a `workflow` can be defined using the `DefineWorkflow` method.
-When a workflow is created in this manner, if contains a `workflow.definition` object. By passing this definition into the `create` method, the trigger will have access to information related to the workflow's definition.
+When a workflow is created in this manner, it contains a `workflow.definition` object. By passing this definition into the `create` method, the trigger will have access to information related to the workflow's definition.
 
 ### Using Trigger Generics at runtime Example 
 
 ```ts
-import type { SlackFunction } from "/deno-slack-sdk/src/types.ts";
+import { SlackFunction } from "deno-slack-sdk/mod.ts";
 import { TriggersFunction, TriggersWorkflow } from "../manifest.ts";
-import { SlackAPI } from "../../deno-slack-api/src/mod.ts";
+import { SlackAPI } from "deno-slack-api/mod.ts";
 
 const triggers: SlackFunction<typeof TriggersFunction.definition> = 
   async (
@@ -28,19 +28,24 @@ const triggers: SlackFunction<typeof TriggersFunction.definition> =
       name: "Request Time off",
       description: "Starts the workflow to request time off",
       workflow: "#/workflows/reverse_workflow",
+      inputs: {
+        a_input: {
+          value: "test_value",
+        }
+      }
     });
   }
 ```
 
 ## Workflow Definition Input with CLI Triggers
 
-A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` or `update` method.
+A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.
 
 ### Using Trigger Generics with CLI Example
 
 ```ts
-import { Trigger } from "../deno-slack-api/src/types.ts";
-import { TriggersWorkflow } from "./manifest.ts";
+import { Trigger } from "deno-slack-api/types.ts";
+import { TriggersWorkflow } from "../manifest.ts";
 
 const trigger: Trigger<typeof TriggersWorkflow.definition> = { //Workflow definition is passed to the trigger object
   type: "shortcut",
@@ -48,7 +53,9 @@ const trigger: Trigger<typeof TriggersWorkflow.definition> = { //Workflow defini
   description: "Starts the workflow to request time off",
   workflow: "#/workflows/list_trigger_workflow",
   inputs: {    //The inputs parameter will now have typeahead based on the Workflow definition being passed in.
-    
+    a_input: {
+      value: "test_value"
+    }
   }
 };
 

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -17,6 +17,8 @@ When dealing with Triggers at runtime, a Workflow definition input can optionall
 import { TriggersWorkflow } from "../manifest.ts";
 import { SlackAPI } from "deno-slack-api/mod.ts";
 
+...
+
 {
   //Inside the function execution logic
   const client = SlackAPI(token);

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -15,7 +15,7 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
 
 const client = SlackAPI(token);
 
-const triggerReturn = await client.workflows.triggers.create<
+const triggerReturn = await client.workflows.triggers.create< //Also works for update
   typeof TriggersWorkflow.definition
 >({
   type: "webhook",

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -22,7 +22,7 @@ const triggerReturn = await client.workflows.triggers.create<
   name: "Request Time off",
   description: "Starts the workflow to request time off",
   workflow: "#/workflows/reverse_workflow",
-  inputs: {
+  inputs: { //inputs can now be autofilled from the Workflow Definition
     a_string: {
       value: "TEST",
     },

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -1,6 +1,6 @@
 # Trigger Generics
 
-When creating or updating a trigger at runtime, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
+When creating or updating a trigger, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
 
 ## Defining A Workflow
 


### PR DESCRIPTION
###  Summary

Added docs on how to use a workflow definition input as a generic for trigger creation.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
