### PR TITLE
Basic support for cursor-based pagination

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -12,7 +12,7 @@ All you need to work on this project is a recent version of [Deno](https://deno.
 
 ### Building
 
-* The majority of this library (`src/generated`) is generated code based off of `src/public-api-methods.ts`.
+* The majority of this library (`src/generated`) is generated code based off of `scripts/src/public-api-methods.ts`.
 * Run `./scripts/generate` to regenerate the API methods code. Unit tests verifying every API method has a corresponding function created for it are also generated in this step.
 
 Run the following from the root of the project:
@@ -20,6 +20,8 @@ Run the following from the root of the project:
 ```
 ./scripts/generate
 ```
+
+For more information on the code generation, have a look at `scripts/README.md`.
 
 ### Testing
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -22,7 +22,7 @@ const customClient = SlackAPI(token, {
 
 ### Using the Slack API Client
 
-Now that you have an instance of the Slack API Client, you have access to its methods. You can call Slack API methods by directly referencing them on the client, such as `client.chat.postMessage()` or `client.pins.add()`. You also have access to the following methods:
+Now that you have an instance of the Slack API Client, you have access to its [methods](https://api.slack.com/methods). You can call Slack API methods by directly referencing them on the client, such as `client.chat.postMessage()` or `client.pins.add()`. You also have access to the following methods:
 - `apiCall`: An async function that accepts two arguments:
   1. `method`: a string which defines which API method you wish to invoke.
   2. `data`: a JSON object representing parameter data to be passed to the API method you wish to invoke; the client will handle serializing it appropriately.
@@ -44,4 +44,29 @@ await client.apiCall("chat.postMessage", {
 
 // respond to a response_url
 await client.response("...", payload);
+```
+
+#### Pagination
+
+A vast majority of Slack API methods support [cursor-based pagination](https://api.slack.com/docs/pagination#cursors). To use cursor-based pagination, start by specifying a `limit` parameter to any API method that returns lists of objects, like so:
+
+```ts
+const messages = await client.conversations.history({
+  channel: myChannelID,
+  limit: 1
+});
+```
+
+Specifying `limit: 1` will ensure the response from the API will contain at most one item.
+
+However, assumining in our above example that the channel being queried has more than one message, we would expect to be able to retrieve more "pages" of results. By inspecting the API response's `response_metadata.next_cursor` value, we can determine if there are any additional pages, and if so, we can use `next_cursor` to retrieve the next page of results, like so:
+
+```ts
+if (messages.response_metadata?.next_cursor) {
+   const moarMessages = await.client.conversations.history({
+     channel: myChannelID,
+     limit: 1,
+     cursor: messages.response_metadata.next_cursor
+   });
+}
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+# Code Generation
+
+A majority of the API client code in this project is generated from code in this directory.
+
+For details, please read through the code under `scripts/src/generate.ts`, but a rough overview of how this works is:
+
+1. `scripts/src/public-api-methods.ts` contains a list of API methods that code will be generated for.
+2. API methods follow a dot-notation "node"-based format that can be interpreted as a kind of tree, e.g. `admin.apps.approve` or `admin.apps.requests.list`. Each word, separated by a period, in the full API "path" name can be considered as a node with zero or more child nodes. For example, building off the previous two API name examples provided, `admin` is a node with a child node `apps`, and `apps` is a node with two child nodes `approve` and `requests`. `approve` is a leaf node that is an API method, whereas `requests` is a node which itself has one further child node `list`; finally, `list` is a leaf node that is an invokable API method. In this way, we model the API using a recursive, node-based construct.
+3. `scripts/src/api-method-nodes.ts` contains the code modeling this recursive node-based approach. This file also contains a hard-coded list of API method leaf node names that map to API methods that return lists of objects. In a majority of cases, these API methods support cursor-based pagination (however, there are a few exceptions to this rule, which is also hard-coded). In this way we are able to mix in different types that enhance or expand on the API method parameters and response properties to account for different patterns of using the APIs (such as cursor-based pagination). In the future, this approach can be used to model other kinds of generic patterns of use of Slack's APIs.

--- a/scripts/generate
+++ b/scripts/generate
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Writes the Function files based on a functions.json file existing alongside this script
-deno run --quiet --allow-read --allow-net --allow-write ./scripts/src/generate.ts
+deno run --allow-read --allow-net --allow-write ./scripts/src/generate.ts
 echo "Formatting Slack function files..."
 deno fmt --quiet ./src/generated/**/*.ts
 echo "Linting Slack function files..."

--- a/scripts/src/api-method-node.ts
+++ b/scripts/src/api-method-node.ts
@@ -1,7 +1,7 @@
 import { pascalCase } from "../../src/deps.ts";
 
 const CURSOR_PAGINATED_API_NAMES = ['getEntities', 'getTeams', 'list', 'search', 'listOriginalConnectedChannelInfo', 'history', 'listConnectInvites', 'members', 'replies', 'conversations'];
-const ACTUALLY_NOT_PAGINATED_EVEN_THOUGH_YOU_MIGHT_THINK_IT_SHOULD_BE = ['bookmarks.list', 'enterprise.auth.idpconfig.list', 'pins.list', 'reminders.list', 'team.preferences.list', 'usergroups.list', 'usergroups.users.list'];
+const PAGINATION_EXCEPTION_LIST = ['bookmarks.list', 'enterprise.auth.idpconfig.list', 'pins.list', 'reminders.list', 'team.preferences.list', 'usergroups.list', 'usergroups.users.list'];
 
 export class APIMethodNode {
   name = "";
@@ -44,8 +44,8 @@ export class APIMethodNode {
 
     // api method with no child nodes
     if (this.isMethod && this.childNodes.length === 0) {
-      if (CURSOR_PAGINATED_API_NAMES.includes(this.name) && !ACTUALLY_NOT_PAGINATED_EVEN_THOUGH_YOU_MIGHT_THINK_IT_SHOULD_BE.includes(this.nodePath)) {
-        code += `${this.name}: SlackAPIMethodCursorPaginated,\n`;
+      if (CURSOR_PAGINATED_API_NAMES.includes(this.name) && !PAGINATION_EXCEPTION_LIST.includes(this.nodePath)) {
+        code += `${this.name}: SlackAPICursorPaginatedMethod,\n`;
       } else {
         code += `${this.name}: SlackAPIMethod,\n`;
       }

--- a/scripts/src/api-method-node.ts
+++ b/scripts/src/api-method-node.ts
@@ -1,5 +1,8 @@
 import { pascalCase } from "../../src/deps.ts";
 
+const CURSOR_PAGINATED_API_NAMES = ['getEntities', 'getTeams', 'list', 'search', 'listOriginalConnectedChannelInfo', 'history', 'listConnectInvites', 'members', 'replies', 'conversations'];
+const ACTUALLY_NOT_PAGINATED_EVEN_THOUGH_YOU_MIGHT_THINK_IT_SHOULD_BE = ['bookmarks.list', 'enterprise.auth.idpconfig.list', 'pins.list', 'reminders.list', 'team.preferences.list', 'usergroups.list', 'usergroups.users.list'];
+
 export class APIMethodNode {
   name = "";
   childNodes: APIMethodNode[] = [];
@@ -41,7 +44,11 @@ export class APIMethodNode {
 
     // api method with no child nodes
     if (this.isMethod && this.childNodes.length === 0) {
-      code += `${this.name}: SlackAPIMethod,\n`;
+      if (CURSOR_PAGINATED_API_NAMES.includes(this.name) && !ACTUALLY_NOT_PAGINATED_EVEN_THOUGH_YOU_MIGHT_THINK_IT_SHOULD_BE.includes(this.nodePath)) {
+        code += `${this.name}: SlackAPIMethodCursorPaginated,\n`;
+      } else {
+        code += `${this.name}: SlackAPIMethod,\n`;
+      }
     }
 
     // api method with child nodes

--- a/scripts/src/generate.ts
+++ b/scripts/src/generate.ts
@@ -86,13 +86,23 @@ export type SlackAPIMethodsType = {
 };
 
 const getGroupCode = (groupNode: APIMethodNode) => {
-  const groupCode = `
-  import { SlackAPIMethod } from "../../types.ts";
-
+  let imports = null;
+  let groupCode = `
   ${groupNode.getTypesCode()}
 `;
+  if (groupCode.match(/SlackAPIMethod[,;]/)) {
+    imports = '{ SlackAPIMethod';
+  }
+  if (groupCode.match(/SlackAPIMethodCursorPaginated[,;]/)) {
+    if (imports !== null) {
+      imports += ', SlackAPIMethodCursorPaginated';
+    } else {
+      imports = '{ SlackAPIMethodCursorPaginated';
+    }
+  }
+  imports += ' }';
 
-  return groupCode;
+  return `import type ${imports} from "../../types.ts";\n${groupCode}`;
 };
 
 const getTestCode = (api: APIMethodNode) => {

--- a/scripts/src/generate.ts
+++ b/scripts/src/generate.ts
@@ -93,11 +93,11 @@ const getGroupCode = (groupNode: APIMethodNode) => {
   if (groupCode.match(/SlackAPIMethod[,;]/)) {
     imports = '{ SlackAPIMethod';
   }
-  if (groupCode.match(/SlackAPIMethodCursorPaginated[,;]/)) {
+  if (groupCode.match(/SlackAPICursorPaginatedMethod[,;]/)) {
     if (imports !== null) {
-      imports += ', SlackAPIMethodCursorPaginated';
+      imports += ', SlackAPICursorPaginatedMethod';
     } else {
-      imports = '{ SlackAPIMethodCursorPaginated';
+      imports = '{ SlackAPICursorPaginatedMethod';
     }
   }
   imports += ' }';

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -244,6 +244,19 @@ Deno.test("serializeData helper function", async (t) => {
       );
     },
   );
+  await t.step(
+    "should not serialize undefined values",
+    () => {
+      assertEquals(
+        serializeData({
+          "hockey": { "good": true, "awesome": "yes" },
+          "baseball": undefined,
+        })
+          .toString(),
+        "hockey=%7B%22good%22%3Atrue%2C%22awesome%22%3A%22yes%22%7D",
+      );
+    },
+  );
 });
 
 Deno.test("SlackApi.setSlackApiUrl()", async (t) => {

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -77,6 +77,9 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
     // Inspired by https://github.com/slackapi/node-slack-sdk/blob/%40slack/web-api%406.7.2/packages/web-api/src/WebClient.ts#L452-L528
 
+    // Skip properties with undefined values.
+    if (value === undefined) return;
+
     const serializedValue: string =
       (typeof value !== "string" ? JSON.stringify(value) : value);
     encodedData[key] = serializedValue;

--- a/src/generated/method-types/admin.ts
+++ b/src/generated/method-types/admin.ts
@@ -1,6 +1,6 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type AdminAPIType = {
@@ -10,30 +10,30 @@ export type AdminAPIType = {
   apps: {
     approve: SlackAPIMethod;
     approved: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     clearResolution: SlackAPIMethod;
     requests: {
       cancel: SlackAPIMethod;
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     restrict: SlackAPIMethod;
     restricted: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     uninstall: SlackAPIMethod;
   };
   auth: {
     policy: {
       assignEntities: SlackAPIMethod;
-      getEntities: SlackAPIMethodCursorPaginated;
+      getEntities: SlackAPICursorPaginatedMethod;
       removeEntities: SlackAPIMethod;
     };
   };
   barriers: {
     create: SlackAPIMethod;
     delete: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
     update: SlackAPIMethod;
   };
   conversations: {
@@ -43,11 +43,11 @@ export type AdminAPIType = {
     delete: SlackAPIMethod;
     disconnectShared: SlackAPIMethod;
     ekm: {
-      listOriginalConnectedChannelInfo: SlackAPIMethodCursorPaginated;
+      listOriginalConnectedChannelInfo: SlackAPICursorPaginatedMethod;
     };
     getConversationPrefs: SlackAPIMethod;
     getCustomRetention: SlackAPIMethod;
-    getTeams: SlackAPIMethodCursorPaginated;
+    getTeams: SlackAPICursorPaginatedMethod;
     invite: SlackAPIMethod;
     removeCustomRetention: SlackAPIMethod;
     rename: SlackAPIMethod;
@@ -56,7 +56,7 @@ export type AdminAPIType = {
       listGroups: SlackAPIMethod;
       removeGroup: SlackAPIMethod;
     };
-    search: SlackAPIMethodCursorPaginated;
+    search: SlackAPICursorPaginatedMethod;
     setConversationPrefs: SlackAPIMethod;
     setCustomRetention: SlackAPIMethod;
     setTeams: SlackAPIMethod;
@@ -65,29 +65,29 @@ export type AdminAPIType = {
   emoji: {
     add: SlackAPIMethod;
     addAlias: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
     remove: SlackAPIMethod;
     rename: SlackAPIMethod;
   };
   inviteRequests: {
     approve: SlackAPIMethod;
     approved: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     denied: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     deny: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
   };
   teams: {
     admins: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     create: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
     owners: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
     settings: {
       info: SlackAPIMethod;
@@ -107,13 +107,13 @@ export type AdminAPIType = {
   users: {
     assign: SlackAPIMethod;
     invite: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
     remove: SlackAPIMethod;
     session: {
       clearSettings: SlackAPIMethod;
       getSettings: SlackAPIMethod;
       invalidate: SlackAPIMethod;
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
       reset: SlackAPIMethod;
       resetBulk: SlackAPIMethod;
       setSettings: SlackAPIMethod;

--- a/src/generated/method-types/admin.ts
+++ b/src/generated/method-types/admin.ts
@@ -1,4 +1,7 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type AdminAPIType = {
   analytics: {
@@ -7,30 +10,30 @@ export type AdminAPIType = {
   apps: {
     approve: SlackAPIMethod;
     approved: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     clearResolution: SlackAPIMethod;
     requests: {
       cancel: SlackAPIMethod;
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     restrict: SlackAPIMethod;
     restricted: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     uninstall: SlackAPIMethod;
   };
   auth: {
     policy: {
       assignEntities: SlackAPIMethod;
-      getEntities: SlackAPIMethod;
+      getEntities: SlackAPIMethodCursorPaginated;
       removeEntities: SlackAPIMethod;
     };
   };
   barriers: {
     create: SlackAPIMethod;
     delete: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
     update: SlackAPIMethod;
   };
   conversations: {
@@ -40,11 +43,11 @@ export type AdminAPIType = {
     delete: SlackAPIMethod;
     disconnectShared: SlackAPIMethod;
     ekm: {
-      listOriginalConnectedChannelInfo: SlackAPIMethod;
+      listOriginalConnectedChannelInfo: SlackAPIMethodCursorPaginated;
     };
     getConversationPrefs: SlackAPIMethod;
     getCustomRetention: SlackAPIMethod;
-    getTeams: SlackAPIMethod;
+    getTeams: SlackAPIMethodCursorPaginated;
     invite: SlackAPIMethod;
     removeCustomRetention: SlackAPIMethod;
     rename: SlackAPIMethod;
@@ -53,7 +56,7 @@ export type AdminAPIType = {
       listGroups: SlackAPIMethod;
       removeGroup: SlackAPIMethod;
     };
-    search: SlackAPIMethod;
+    search: SlackAPIMethodCursorPaginated;
     setConversationPrefs: SlackAPIMethod;
     setCustomRetention: SlackAPIMethod;
     setTeams: SlackAPIMethod;
@@ -62,29 +65,29 @@ export type AdminAPIType = {
   emoji: {
     add: SlackAPIMethod;
     addAlias: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
     remove: SlackAPIMethod;
     rename: SlackAPIMethod;
   };
   inviteRequests: {
     approve: SlackAPIMethod;
     approved: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     denied: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     deny: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
   };
   teams: {
     admins: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     create: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
     owners: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
     settings: {
       info: SlackAPIMethod;
@@ -104,13 +107,13 @@ export type AdminAPIType = {
   users: {
     assign: SlackAPIMethod;
     invite: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
     remove: SlackAPIMethod;
     session: {
       clearSettings: SlackAPIMethod;
       getSettings: SlackAPIMethod;
       invalidate: SlackAPIMethod;
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
       reset: SlackAPIMethod;
       resetBulk: SlackAPIMethod;
       setSettings: SlackAPIMethod;

--- a/src/generated/method-types/api.ts
+++ b/src/generated/method-types/api.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type ApiAPIType = {
   test: SlackAPIMethod;

--- a/src/generated/method-types/apps.ts
+++ b/src/generated/method-types/apps.ts
@@ -1,4 +1,7 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type AppsAPIType = {
   connections: {
@@ -6,7 +9,7 @@ export type AppsAPIType = {
   };
   event: {
     authorizations: {
-      list: SlackAPIMethod;
+      list: SlackAPIMethodCursorPaginated;
     };
   };
   manifest: {

--- a/src/generated/method-types/apps.ts
+++ b/src/generated/method-types/apps.ts
@@ -1,6 +1,6 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type AppsAPIType = {
@@ -9,7 +9,7 @@ export type AppsAPIType = {
   };
   event: {
     authorizations: {
-      list: SlackAPIMethodCursorPaginated;
+      list: SlackAPICursorPaginatedMethod;
     };
   };
   manifest: {

--- a/src/generated/method-types/auth.ts
+++ b/src/generated/method-types/auth.ts
@@ -1,9 +1,12 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type AuthAPIType = {
   revoke: SlackAPIMethod;
   teams: {
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
   };
   test: SlackAPIMethod;
 };

--- a/src/generated/method-types/auth.ts
+++ b/src/generated/method-types/auth.ts
@@ -1,12 +1,12 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type AuthAPIType = {
   revoke: SlackAPIMethod;
   teams: {
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
   };
   test: SlackAPIMethod;
 };

--- a/src/generated/method-types/bookmarks.ts
+++ b/src/generated/method-types/bookmarks.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type BookmarksAPIType = {
   add: SlackAPIMethod;

--- a/src/generated/method-types/bots.ts
+++ b/src/generated/method-types/bots.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type BotsAPIType = {
   info: SlackAPIMethod;

--- a/src/generated/method-types/calls.ts
+++ b/src/generated/method-types/calls.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type CallsAPIType = {
   add: SlackAPIMethod;

--- a/src/generated/method-types/chat.ts
+++ b/src/generated/method-types/chat.ts
@@ -1,6 +1,6 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type ChatAPIType = {
@@ -10,7 +10,7 @@ export type ChatAPIType = {
   meMessage: SlackAPIMethod;
   postEphemeral: SlackAPIMethod;
   scheduledMessages: {
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
   };
   scheduleMessage: SlackAPIMethod;
   unfurl: SlackAPIMethod;

--- a/src/generated/method-types/chat.ts
+++ b/src/generated/method-types/chat.ts
@@ -1,4 +1,7 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type ChatAPIType = {
   delete: SlackAPIMethod;
@@ -7,7 +10,7 @@ export type ChatAPIType = {
   meMessage: SlackAPIMethod;
   postEphemeral: SlackAPIMethod;
   scheduledMessages: {
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
   };
   scheduleMessage: SlackAPIMethod;
   unfurl: SlackAPIMethod;

--- a/src/generated/method-types/conversations.ts
+++ b/src/generated/method-types/conversations.ts
@@ -1,6 +1,6 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type ConversationsAPIType = {
@@ -10,20 +10,20 @@ export type ConversationsAPIType = {
   close: SlackAPIMethod;
   create: SlackAPIMethod;
   declineSharedInvite: SlackAPIMethod;
-  history: SlackAPIMethodCursorPaginated;
+  history: SlackAPICursorPaginatedMethod;
   info: SlackAPIMethod;
   invite: SlackAPIMethod;
   inviteShared: SlackAPIMethod;
   join: SlackAPIMethod;
   kick: SlackAPIMethod;
   leave: SlackAPIMethod;
-  list: SlackAPIMethodCursorPaginated;
-  listConnectInvites: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
+  listConnectInvites: SlackAPICursorPaginatedMethod;
   mark: SlackAPIMethod;
-  members: SlackAPIMethodCursorPaginated;
+  members: SlackAPICursorPaginatedMethod;
   open: SlackAPIMethod;
   rename: SlackAPIMethod;
-  replies: SlackAPIMethodCursorPaginated;
+  replies: SlackAPICursorPaginatedMethod;
   setPurpose: SlackAPIMethod;
   setTopic: SlackAPIMethod;
   unarchive: SlackAPIMethod;

--- a/src/generated/method-types/conversations.ts
+++ b/src/generated/method-types/conversations.ts
@@ -1,4 +1,7 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type ConversationsAPIType = {
   acceptSharedInvite: SlackAPIMethod;
@@ -7,20 +10,20 @@ export type ConversationsAPIType = {
   close: SlackAPIMethod;
   create: SlackAPIMethod;
   declineSharedInvite: SlackAPIMethod;
-  history: SlackAPIMethod;
+  history: SlackAPIMethodCursorPaginated;
   info: SlackAPIMethod;
   invite: SlackAPIMethod;
   inviteShared: SlackAPIMethod;
   join: SlackAPIMethod;
   kick: SlackAPIMethod;
   leave: SlackAPIMethod;
-  list: SlackAPIMethod;
-  listConnectInvites: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
+  listConnectInvites: SlackAPIMethodCursorPaginated;
   mark: SlackAPIMethod;
-  members: SlackAPIMethod;
+  members: SlackAPIMethodCursorPaginated;
   open: SlackAPIMethod;
   rename: SlackAPIMethod;
-  replies: SlackAPIMethod;
+  replies: SlackAPIMethodCursorPaginated;
   setPurpose: SlackAPIMethod;
   setTopic: SlackAPIMethod;
   unarchive: SlackAPIMethod;

--- a/src/generated/method-types/dialog.ts
+++ b/src/generated/method-types/dialog.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type DialogAPIType = {
   open: SlackAPIMethod;

--- a/src/generated/method-types/dnd.ts
+++ b/src/generated/method-types/dnd.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type DndAPIType = {
   endDnd: SlackAPIMethod;

--- a/src/generated/method-types/emoji.ts
+++ b/src/generated/method-types/emoji.ts
@@ -1,5 +1,5 @@
-import type { SlackAPIMethodCursorPaginated } from "../../types.ts";
+import type { SlackAPICursorPaginatedMethod } from "../../types.ts";
 
 export type EmojiAPIType = {
-  list: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
 };

--- a/src/generated/method-types/emoji.ts
+++ b/src/generated/method-types/emoji.ts
@@ -1,5 +1,5 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethodCursorPaginated } from "../../types.ts";
 
 export type EmojiAPIType = {
-  list: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
 };

--- a/src/generated/method-types/enterprise.ts
+++ b/src/generated/method-types/enterprise.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type EnterpriseAPIType = {
   auth: {

--- a/src/generated/method-types/files.ts
+++ b/src/generated/method-types/files.ts
@@ -1,4 +1,7 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type FilesAPIType = {
   comments: {
@@ -6,11 +9,11 @@ export type FilesAPIType = {
   };
   delete: SlackAPIMethod;
   info: SlackAPIMethod;
-  list: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
   remote: {
     add: SlackAPIMethod;
     info: SlackAPIMethod;
-    list: SlackAPIMethod;
+    list: SlackAPIMethodCursorPaginated;
     remove: SlackAPIMethod;
     share: SlackAPIMethod;
     update: SlackAPIMethod;

--- a/src/generated/method-types/files.ts
+++ b/src/generated/method-types/files.ts
@@ -1,6 +1,6 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type FilesAPIType = {
@@ -9,11 +9,11 @@ export type FilesAPIType = {
   };
   delete: SlackAPIMethod;
   info: SlackAPIMethod;
-  list: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
   remote: {
     add: SlackAPIMethod;
     info: SlackAPIMethod;
-    list: SlackAPIMethodCursorPaginated;
+    list: SlackAPICursorPaginatedMethod;
     remove: SlackAPIMethod;
     share: SlackAPIMethod;
     update: SlackAPIMethod;

--- a/src/generated/method-types/migration.ts
+++ b/src/generated/method-types/migration.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type MigrationAPIType = {
   exchange: SlackAPIMethod;

--- a/src/generated/method-types/oauth.ts
+++ b/src/generated/method-types/oauth.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type OauthAPIType = {
   access: SlackAPIMethod;

--- a/src/generated/method-types/openid.ts
+++ b/src/generated/method-types/openid.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type OpenidAPIType = {
   connect: {

--- a/src/generated/method-types/pins.ts
+++ b/src/generated/method-types/pins.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type PinsAPIType = {
   add: SlackAPIMethod;

--- a/src/generated/method-types/reactions.ts
+++ b/src/generated/method-types/reactions.ts
@@ -1,8 +1,11 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type ReactionsAPIType = {
   add: SlackAPIMethod;
   get: SlackAPIMethod;
-  list: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
   remove: SlackAPIMethod;
 };

--- a/src/generated/method-types/reactions.ts
+++ b/src/generated/method-types/reactions.ts
@@ -1,11 +1,11 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type ReactionsAPIType = {
   add: SlackAPIMethod;
   get: SlackAPIMethod;
-  list: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
   remove: SlackAPIMethod;
 };

--- a/src/generated/method-types/reminders.ts
+++ b/src/generated/method-types/reminders.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type RemindersAPIType = {
   add: SlackAPIMethod;

--- a/src/generated/method-types/rtm.ts
+++ b/src/generated/method-types/rtm.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type RtmAPIType = {
   connect: SlackAPIMethod;

--- a/src/generated/method-types/search.ts
+++ b/src/generated/method-types/search.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type SearchAPIType = {
   all: SlackAPIMethod;

--- a/src/generated/method-types/stars.ts
+++ b/src/generated/method-types/stars.ts
@@ -1,10 +1,10 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type StarsAPIType = {
   add: SlackAPIMethod;
-  list: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
   remove: SlackAPIMethod;
 };

--- a/src/generated/method-types/stars.ts
+++ b/src/generated/method-types/stars.ts
@@ -1,7 +1,10 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type StarsAPIType = {
   add: SlackAPIMethod;
-  list: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
   remove: SlackAPIMethod;
 };

--- a/src/generated/method-types/team.ts
+++ b/src/generated/method-types/team.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type TeamAPIType = {
   accessLogs: SlackAPIMethod;

--- a/src/generated/method-types/tooling.ts
+++ b/src/generated/method-types/tooling.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type ToolingAPIType = {
   tokens: {

--- a/src/generated/method-types/usergroups.ts
+++ b/src/generated/method-types/usergroups.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type UsergroupsAPIType = {
   create: SlackAPIMethod;

--- a/src/generated/method-types/users.ts
+++ b/src/generated/method-types/users.ts
@@ -1,15 +1,15 @@
 import type {
+  SlackAPICursorPaginatedMethod,
   SlackAPIMethod,
-  SlackAPIMethodCursorPaginated,
 } from "../../types.ts";
 
 export type UsersAPIType = {
-  conversations: SlackAPIMethodCursorPaginated;
+  conversations: SlackAPICursorPaginatedMethod;
   deletePhoto: SlackAPIMethod;
   getPresence: SlackAPIMethod;
   identity: SlackAPIMethod;
   info: SlackAPIMethod;
-  list: SlackAPIMethodCursorPaginated;
+  list: SlackAPICursorPaginatedMethod;
   lookupByEmail: SlackAPIMethod;
   profile: {
     get: SlackAPIMethod;

--- a/src/generated/method-types/users.ts
+++ b/src/generated/method-types/users.ts
@@ -1,12 +1,15 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type {
+  SlackAPIMethod,
+  SlackAPIMethodCursorPaginated,
+} from "../../types.ts";
 
 export type UsersAPIType = {
-  conversations: SlackAPIMethod;
+  conversations: SlackAPIMethodCursorPaginated;
   deletePhoto: SlackAPIMethod;
   getPresence: SlackAPIMethod;
   identity: SlackAPIMethod;
   info: SlackAPIMethod;
-  list: SlackAPIMethod;
+  list: SlackAPIMethodCursorPaginated;
   lookupByEmail: SlackAPIMethod;
   profile: {
     get: SlackAPIMethod;

--- a/src/generated/method-types/views.ts
+++ b/src/generated/method-types/views.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type ViewsAPIType = {
   open: SlackAPIMethod;

--- a/src/generated/method-types/workflows.ts
+++ b/src/generated/method-types/workflows.ts
@@ -1,4 +1,4 @@
-import { SlackAPIMethod } from "../../types.ts";
+import type { SlackAPIMethod } from "../../types.ts";
 
 export type WorkflowsAPIType = {
   stepCompleted: SlackAPIMethod;

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -1,4 +1,9 @@
-import { BaseMethodArgs, BaseResponse, CursorPaginationArgs, CursorPaginationResponse } from "../types.ts";
+import {
+  BaseMethodArgs,
+  BaseResponse,
+  CursorPaginationArgs,
+  CursorPaginationResponse,
+} from "../types.ts";
 
 // apps.datastore Types
 export type DatastoreSchema = {

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -1,4 +1,4 @@
-import { BaseMethodArgs, BaseResponse } from "../types.ts";
+import { BaseMethodArgs, BaseResponse, CursorPaginationArgs, CursorPaginationResponse } from "../types.ts";
 
 // apps.datastore Types
 export type DatastoreSchema = {
@@ -80,6 +80,7 @@ export type DatastoreQueryArgs<
   Schema extends DatastoreSchema,
 > =
   & BaseMethodArgs
+  & CursorPaginationArgs
   & {
     /**
      * @description The name of the datastore
@@ -88,14 +89,13 @@ export type DatastoreQueryArgs<
     expression?: string;
     "expression_attributes"?: Record<string, string>;
     "expression_values"?: Record<string, string | boolean | number>;
-    limit?: number;
-    cursor?: string;
   };
 
 export type DatastoreQueryResponse<
   Schema extends DatastoreSchema,
 > =
   & BaseResponse
+  & CursorPaginationResponse
   & {
     /**
      * @description The name of the datastore

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -89,6 +89,7 @@ export type DatastoreQueryArgs<
     "expression_attributes"?: Record<string, string>;
     "expression_values"?: Record<string, string | boolean | number>;
     limit?: number;
+    cursor?: string;
   };
 
 export type DatastoreQueryResponse<

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -1,4 +1,4 @@
-import { BaseMethodArgs, BaseResponse } from "../../../types.ts";
+import { BaseMethodArgs, BaseResponse, CursorPaginationArgs, CursorPaginationResponse } from "../../../types.ts";
 import { InputParameterSchema, WorkflowInputs } from "./inputs.ts";
 import {
   EventTrigger,
@@ -88,7 +88,7 @@ type ValidTriggerResponseObjects =
   | ScheduledTriggerResponseObject<WorkflowSchema>
   | WebhookTriggerResponseObject<WorkflowSchema>;
 
-type ListResponse = {
+type ListResponse = CursorPaginationResponse & {
   ok: true;
   /** @description List of triggers in the workspace */
   triggers: ValidTriggerResponseObjects[];
@@ -98,7 +98,7 @@ type ListTriggerResponse = Promise<
   ListResponse | FailedListTriggerResponse
 >;
 
-type FailedListTriggerResponse = BaseResponse & {
+type FailedListTriggerResponse = BaseResponse & CursorPaginationResponse & {
   ok: false;
   /** @description no triggers are returned on a failed response */
   triggers?: never;
@@ -151,6 +151,6 @@ export type TypedWorkflowsTriggersMethodTypes = {
   ) => DeleteTriggerResponse;
   /** @description Method to list existing triggers in the workspace */
   list: (
-    args?: BaseMethodArgs & ListArgs,
+    args?: BaseMethodArgs & CursorPaginationArgs & ListArgs,
   ) => ListTriggerResponse;
 };

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -1,4 +1,9 @@
-import { BaseMethodArgs, BaseResponse, CursorPaginationArgs, CursorPaginationResponse } from "../../../types.ts";
+import {
+  BaseMethodArgs,
+  BaseResponse,
+  CursorPaginationArgs,
+  CursorPaginationResponse,
+} from "../../../types.ts";
 import { InputParameterSchema, WorkflowInputs } from "./inputs.ts";
 import {
   EventTrigger,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,15 +28,6 @@ export type BaseResponse = {
   "response_metadata"?: {
     warnings?: string[];
     messages?: string[];
-    /**
-     * @description A pointer that can be provided as parameter for a follow-up
-     * call to the same API to retrieve the next set of results, should more exist.
-     * If this property does not exist or is the empty string, there are no further
-     * results to retrieve.
-     * See {@link https://api.slack.com/docs/pagination#cursors our docs on cursor-based pagination}
-     * for more details
-     */
-    next_cursor?: string;
   };
   // deno-lint-ignore no-explicit-any
   [otherOptions: string]: any;
@@ -76,6 +67,9 @@ export type BaseMethodArgs = {
    * for this single API call rather than the token provided when creating the client.
    */
   token?: string;
+};
+
+export type CursorPaginationArgs = {
   /**
    * @description Paginate through collections of data by setting the `cursor` parameter
    * to a `next_cursor` attribute returned by a previous request's `response_metadata`.
@@ -86,13 +80,27 @@ export type BaseMethodArgs = {
   cursor?: string;
   /**
    * @description The maximum number of items to return. Fewer than the requested
-   * number of items may be returned, even if the end of the users list hasn't
+   * number of items may be returned, even if the end of the result list hasn't
    * been reached.
    * Used in conjunction with `cursor`, these parameters allow for
    * {@link https://api.slack.com/docs/pagination#cursors cursor-based pagination}.
    */
   limit?: number;
 };
+
+export type CursorPaginationResponse = {
+  "response_metadata"?: {
+    /**
+     * @description A pointer that can be provided as parameter for a follow-up
+     * call to the same API to retrieve the next set of results, should more exist.
+     * If this property does not exist or is the empty string, there are no further
+     * results to retrieve.
+     * See {@link https://api.slack.com/docs/pagination#cursors our docs on cursor-based pagination}
+     * for more details
+     */
+    next_cursor?: string;
+  };
+}
 
 export type SlackAPIMethodArgs = BaseMethodArgs & {
   [name: string]: unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,7 @@ export type CursorPaginationResponse = {
      */
     next_cursor?: string;
   };
-}
+};
 
 export type SlackAPIMethodArgs = BaseMethodArgs & {
   [name: string]: unknown;
@@ -111,5 +111,7 @@ export type SlackAPIMethod = {
 };
 
 export type SlackAPIMethodCursorPaginated = {
-  (args?: SlackAPIMethodArgs & CursorPaginationArgs): Promise<BaseResponse & CursorPaginationResponse>;
+  (
+    args?: SlackAPIMethodArgs & CursorPaginationArgs,
+  ): Promise<BaseResponse & CursorPaginationResponse>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type BaseResponse = {
   "response_metadata"?: {
     warnings?: string[];
     messages?: string[];
+    next_cursor?: string;
   };
   // deno-lint-ignore no-explicit-any
   [otherOptions: string]: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export type SlackAPIMethod = {
   (args?: SlackAPIMethodArgs): Promise<BaseResponse>;
 };
 
-export type SlackAPIPaginatedCursorMethod = {
+export type SlackAPICursorPaginatedMethod = {
   (
     args?: SlackAPIMethodArgs & CursorPaginationArgs,
   ): Promise<BaseResponse & CursorPaginationResponse>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,3 +109,7 @@ export type SlackAPIMethodArgs = BaseMethodArgs & {
 export type SlackAPIMethod = {
   (args?: SlackAPIMethodArgs): Promise<BaseResponse>;
 };
+
+export type SlackAPIMethodCursorPaginated = {
+  (args?: SlackAPIMethodArgs & CursorPaginationArgs): Promise<BaseResponse & CursorPaginationResponse>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export type SlackAPIMethod = {
   (args?: SlackAPIMethodArgs): Promise<BaseResponse>;
 };
 
-export type SlackAPIMethodCursorPaginated = {
+export type SlackAPIPaginatedCursorMethod = {
   (
     args?: SlackAPIMethodArgs & CursorPaginationArgs,
   ): Promise<BaseResponse & CursorPaginationResponse>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,16 +10,32 @@ export type {
 } from "./typed-method-types/workflows/triggers/mod.ts";
 
 export type BaseResponse = {
-  /** `true` if the response from the server was successful, `false` otherwise. */
+  /**
+   * @description `true` if the response from the server was successful, `false` otherwise.
+   */
   ok: boolean;
-  /** Optional error description returned by the server. */
+  /**
+   * @description: Optional error description returned by the server.
+   */
   error?: string;
-  /** Optional list of warnings returned by the server. */
+  /**
+   * @description Optional list of warnings returned by the server.
+   */
   warnings?: string[];
-  /** Optional metadata about the response returned by the server. */
+  /**
+   * @description Optional metadata about the response returned by the server.
+   */
   "response_metadata"?: {
     warnings?: string[];
     messages?: string[];
+    /**
+     * @description A pointer that can be provided as parameter for a follow-up
+     * call to the same API to retrieve the next set of results, should more exist.
+     * If this property does not exist or is the empty string, there are no further
+     * results to retrieve.
+     * See {@link https://api.slack.com/docs/pagination#cursors our docs on cursor-based pagination}
+     * for more details
+     */
     next_cursor?: string;
   };
   // deno-lint-ignore no-explicit-any
@@ -56,9 +72,26 @@ export type SlackAPIOptions = {
 
 export type BaseMethodArgs = {
   /**
-   * @description Optional override token. If set, it will be used as the token for this single api call rather than the token provided when creating the client.
+   * @description Optional override token. If set, it will be used as the token
+   * for this single API call rather than the token provided when creating the client.
    */
   token?: string;
+  /**
+   * @description Paginate through collections of data by setting the `cursor` parameter
+   * to a `next_cursor` attribute returned by a previous request's `response_metadata`.
+   * Default value fetches the first "page" of the collection.
+   * Used in conjunction with `limit`, these parameters allow for
+   * {@link https://api.slack.com/docs/pagination#cursors cursor-based pagination}.
+   */
+  cursor?: string;
+  /**
+   * @description The maximum number of items to return. Fewer than the requested
+   * number of items may be returned, even if the end of the users list hasn't
+   * been reached.
+   * Used in conjunction with `cursor`, these parameters allow for
+   * {@link https://api.slack.com/docs/pagination#cursors cursor-based pagination}.
+   */
+  limit?: number;
 };
 
 export type SlackAPIMethodArgs = BaseMethodArgs & {


### PR DESCRIPTION
Adds types to API methods for basic cursor-based pagination.

Added some docs for how to use it too.

Worth noting:

- This does not cover APIs that support timeline-based pagination or 'traditional' pagination (see [here](https://api.slack.com/docs/pagination#classic)). By my count, there are 12 API methods that support these older style based pagination approaches. Some of these _also_ support cursor-based pagination.
- There is existing support for pagination via async iterators in bolt-js (using an [API called `paginate()`](https://slack.dev/node-slack-sdk/web-api#pagination)). Not sure if we want to do something similar here, up for discussion.