### PR TITLE
Added once and hourly frequency types to scheduled trigger

### DIFF
--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -92,7 +92,7 @@ const schedule: ScheduledTrigger = {
     workflow: "#/workflows/example",
     inputs: {},
     schedule: {
-      start_time: "2022-03-01T15:00:00Z",
+      start_time: "2022-03-01T14:00:00Z",
       timezone: "asia/kolkata",
       frequency: {
         type: "once",

--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -92,7 +92,7 @@ const schedule: ScheduledTrigger = {
     workflow: "#/workflows/example",
     inputs: {},
     schedule: {
-      start_time: "2022-03-01T14:00:00Z",
+      start_time: "2022-03-01T15:00:00Z",
       timezone: "asia/kolkata",
       frequency: {
         type: "once",

--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -17,7 +17,7 @@ Both Single Occurrence and Recurring Schedules have common base attributes:
 | `start_time`      | Yes  |An ISO 8601 date string of when this scheduled Trigger should start (i.e. "2022-03-01T14:00:00Z")|
 | `timezone`      | No  |A timezone string to use for scheduling (Defaults to UTC if left blank)|
 
-A Single occurrence schedule can be created using just these two parameters, however a recurring schedule may also include the following parameters: 
+A Single occurrence schedule can be created using just these two parameters or along with these parameter explicilty mentioning once frequency type, however a recurring schedule may also include the following parameters: 
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
@@ -81,6 +81,40 @@ const schedule: ScheduledTrigger = {
     schedule: {
       start_time: "2022-03-01T14:00:00Z",
       timezone: "asia/kolkata",
+    },
+  };
+``` 
+### Single Occurence Schedule with Time Zone and Once Frequency Type
+```ts
+const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "#/workflows/example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      timezone: "asia/kolkata",
+      frequency: {
+        type: "once",
+      },
+    },
+  };
+``` 
+
+### Recurring Hourly Schedule
+```ts
+const schedule: ScheduledTrigger = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "#/workflows/example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      end_time: "2022-05-01T14:00:00Z",
+      frequency: {
+        type: "hourly",
+        repeats_every: 2,
+      },
     },
   };
 ```

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -8,6 +8,8 @@ import {
 } from "./mod.ts";
 
 export const SCHEDULE_FREQUENCY = {
+  Once: "once",
+  Hourly: "hourly",
   Daily: "daily",
   Weekly: "weekly",
   Monthly: "monthly",
@@ -42,6 +44,18 @@ type BaseFrequencyType = {
   on_week_num?: 1 | 2 | 3 | 4 | -1;
 };
 
+type OnceFrequencyType = {
+  /** @description How often the trigger will activate */
+  type: typeof SCHEDULE_FREQUENCY.Once;
+};
+
+type HourlyFrequencyType =
+  & {
+    /** @description How often the trigger will activate */
+    type: typeof SCHEDULE_FREQUENCY.Hourly;
+  }
+  & Pick<BaseFrequencyType, "repeats_every">;
+
 type DailyFrequencyType =
   & {
     /** @description How often the trigger will activate */
@@ -67,6 +81,7 @@ type YearlyFrequencyType = {
 } & Pick<BaseFrequencyType, "repeats_every">;
 
 type FrequencyType =
+  | HourlyFrequencyType
   | DailyFrequencyType
   | WeeklyFrequencyType
   | MonthlyFrequencyType
@@ -86,7 +101,7 @@ type BaseTriggerSchedule = {
 };
 
 type SingleOccurrenceTriggerSchedule = BaseTriggerSchedule & {
-  frequency?: never;
+  frequency?: OnceFrequencyType;
   end_time?: never;
   occurrence_count?: never;
 };

--- a/src/typed-method-types/workflows/triggers/tests/scheduled_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/scheduled_test.ts
@@ -61,6 +61,39 @@ Deno.test("Scheduled Triggers can be set just once", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
+Deno.test("Scheduled Triggers can be set just once with explicit once frequency type", () => {
+  // deno-lint-ignore no-explicit-any
+  const schedule: ScheduledTrigger<any> = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "#/workflows/example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      timezone: "asia/kolkata",
+      frequency: { type: "once" },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
+Deno.test("Scheduled Triggers can be set to be recurring hourly", () => {
+  // deno-lint-ignore no-explicit-any
+  const schedule: ScheduledTrigger<any> = {
+    name: "Sample",
+    type: TriggerTypes.Scheduled,
+    workflow: "#/workflows/example",
+    inputs: {},
+    schedule: {
+      start_time: "2022-03-01T14:00:00Z",
+      end_time: "2022-05-01T14:00:00Z",
+      occurrence_count: 3,
+      frequency: { type: "hourly", "repeats_every": 1 },
+    },
+  };
+  assertEquals(schedule.type, TriggerTypes.Scheduled);
+});
+
 Deno.test("Scheduled Triggers can be set to be recurring", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {


### PR DESCRIPTION
###  Summary
This PR adds support of additional two new frequency types `once` and `hourly` to schedule triggers

### Testing
In order to test this, point your app to this branch and instantiate your client within a runtime function definition and use client.workflows.triggers.create to create a Scheduled trigger with either of following configurations:

1. Trigger to run once only 
```
await client.workflows.triggers.create({
    type: "scheduled",
    workflow: "example",
    inputs: {},
    name: "example",
    schedule: {
    start_time: "2022-11-04T7:40:00Z",
    timezone: "UTC",
    frequency: {
      type: "once",
    },
  },
  });
```
or 
```
await client.workflows.triggers.create({
    type: "scheduled",
    workflow: "example",
    inputs: {},
    name: "example",
    schedule: {
    start_time: "2022-11-04T7:40:00Z",
    timezone: "UTC",
  },
  });
```

2. Trigger to run on hourly basis
```
await client.workflows.triggers.create({
    type: "scheduled",
    workflow: "example",
    inputs: {},
    name: "example",
    schedule: {
      start_time: "2022-11-04T7:40:00Z",
      end_time: "2022-11-06T7:40:00Z",
      frequency: {
        type: "hourly",
        repeats_every: 2,
      },
    },
  });
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
