### PR TITLE
Datastore get and delete should use id instead of the name of the primary key

### DIFF
--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -53,12 +53,10 @@ export type DatastoreGetArgs<
 > =
   & {
     /**
-     * @description The primary key of the item to retreive
+     * @description The primary key of the item to retrieve
      */
     // deno-lint-ignore no-explicit-any
-    [k in Schema["primary_key"]]: any;
-  }
-  & {
+    id: any;
     /**
      * @description The name of the datastore
      */
@@ -120,9 +118,7 @@ export type DatastoreDeleteArgs<
      * @description The primary key of the item to delete
      */
     // deno-lint-ignore no-explicit-any
-    [k in Schema["primary_key"]]: any;
-  }
-  & {
+    id: any;
     /**
      * @description The name of the datastore
      */


### PR DESCRIPTION
###  Summary

Change the `get` and `delete` methods to use `id` instead of the name of the `primary_key` based on API spec

### Testing

1. Create a datastore
2. Generate a unique id for the datastore
3. Use `datastore.put` to create a record
4. Chain that record into calls to `datastore.get` and `datastore.delete`

```ts
const getResp = await client.apps.datastore.get<
      typeof MyDatastore.definition
>({
      datastore: "MyDatastore",
      id: uuid, // <-- the line
});

const deleteResp = await client.apps.datastore.delete<
      typeof MyDatastore.definition
>({
      datastore: "MyDatastore",
      id: uuid, // <-- the line
});
```

### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
