### PR TITLE
Introducing a new WorkflowInput type: `customizable`.

### DIFF
--- a/src/typed-method-types/workflows/triggers/inputs.ts
+++ b/src/typed-method-types/workflows/triggers/inputs.ts
@@ -10,11 +10,26 @@ export type InputParameterSchema = {
   required: (string | number)[];
 };
 
-/** The structure that must be provided to the workflow input to pass a value */
-type WorkflowInput = {
+interface BaseWorkflowInputs {
+  /** @description The value of the workflow input parameter during workflow execution. Template variables may be used here. */
+  value?: unknown;
+  /** @description Set to `true` to allow the input parameter to be customizable, meaning its value is provided separately from the trigger. */
+  customizable?: true;
+}
+
+type WorkflowInputValue = BaseWorkflowInputs & {
   // deno-lint-ignore no-explicit-any
   value: any;
+  customizable?: never;
 };
+
+type WorkflowInputCustomizableValue = BaseWorkflowInputs & {
+  customizable: true;
+  value?: never;
+};
+
+/** The structure that must be provided to the workflow input to pass a value */
+type WorkflowInput = WorkflowInputValue | WorkflowInputCustomizableValue;
 
 /** The structure for when inputs are empty */
 type EmptyInputs = {
@@ -63,7 +78,7 @@ type WorkflowInputsType<Params extends InputParameterSchema> =
  */
 export type WorkflowInputs<WorkflowDefinition extends WorkflowSchema> =
   WorkflowDefinition["title"] extends NO_GENERIC_TITLE ? {
-      /** @description The inputs provided to the workflow */
+      /** @description The inputs provided to the workflow. Either `value` or `customizable` should be provided, but not both. */
       inputs?: Record<string, WorkflowInput>;
     }
     // This also intentionally avoids Distributive Conditional Types, so be careful removing the following square brackets

--- a/src/typed-method-types/workflows/triggers/tests/fixtures/workflows.ts
+++ b/src/typed-method-types/workflows/triggers/tests/fixtures/workflows.ts
@@ -21,6 +21,17 @@ export type OptionalInputWorkflow = ExampleWorkflow & {
   };
 };
 
+export type OptionalCustomizableInputWorkflow = ExampleWorkflow & {
+  input_parameters: {
+    properties: {
+      customizable: {
+        type: "boolean";
+      };
+    };
+    required: [];
+  };
+};
+
 export type RequiredInputWorkflow = ExampleWorkflow & {
   input_parameters: {
     properties: {
@@ -41,7 +52,21 @@ export type MixedInputWorkflow = ExampleWorkflow & {
       optional: {
         type: "string";
       };
+      customizable: {
+        type: "boolean";
+      };
     };
     required: ["required"];
+  };
+};
+
+export type CustomizableInputWorkflow = ExampleWorkflow & {
+  input_parameters: {
+    properties: {
+      customizable: {
+        type: "boolean";
+      };
+    };
+    required: ["customizable"];
   };
 };

--- a/src/typed-method-types/workflows/triggers/tests/trigger-workflow_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/trigger-workflow_test.ts
@@ -5,9 +5,11 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.99.0/testing/asserts.ts";
 import type {
+  CustomizableInputWorkflow,
   ExampleWorkflow,
   MixedInputWorkflow,
   NoInputWorkflow,
+  OptionalCustomizableInputWorkflow,
   OptionalInputWorkflow,
   RequiredInputWorkflow,
 } from "./fixtures/workflows.ts";
@@ -382,6 +384,136 @@ Deno.test("Trigger inputs are powered by generics", async (t) => {
 
         assert(true);
       });
+    });
+
+    await t.step("handles workflow with customizable inputs", async (t) => {
+      await t.step("allows customizable input to be set", async () => {
+        const _: Trigger<CustomizableInputWorkflow> = {
+          name: "TEST",
+          type: "shortcut",
+          workflow: "#/workflows/example",
+          inputs: { customizable: { customizable: true } },
+        };
+        await client.workflows.triggers.create<CustomizableInputWorkflow>({
+          name: "TEST",
+          type: "shortcut",
+          workflow: "#/workflows/example",
+          inputs: { customizable: { customizable: true } },
+        });
+        assert(true);
+      });
+
+      await t.step("allows optional customizable input to be set", async () => {
+        const _: Trigger<CustomizableInputWorkflow> = {
+          name: "TEST",
+          type: "shortcut",
+          workflow: "#/workflows/example",
+          inputs: { customizable: { customizable: true } },
+        };
+        await client.workflows.triggers.create<CustomizableInputWorkflow>({
+          name: "TEST",
+          type: "shortcut",
+          workflow: "#/workflows/example",
+          inputs: { customizable: { customizable: true } },
+        });
+        assert(true);
+      });
+
+      await t.step(
+        "allows empty optional customizable inputs to be set",
+        async () => {
+          const _: Trigger<OptionalCustomizableInputWorkflow> = {
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {},
+          };
+          await client.workflows.triggers.create<
+            OptionalCustomizableInputWorkflow
+          >({
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {},
+          });
+          assert(true);
+        },
+      );
+
+      await t.step(
+        "catches if customizable and value are set",
+        async () => {
+          const _: Trigger<CustomizableInputWorkflow> = {
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error invalid WorkflowInput type
+              customizable: { value: "string", customizable: true },
+            },
+          };
+          await client.workflows.triggers.create<CustomizableInputWorkflow>({
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error invalid WorkflowInput type
+              customizable: { value: "string", customizable: true },
+            },
+          });
+          assert(true);
+        },
+      );
+
+      await t.step(
+        "catches if customizable is not a boolean",
+        async () => {
+          const _: Trigger<CustomizableInputWorkflow> = {
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error customizable must be a boolean
+              customizable: { customizable: "incorrect type" },
+            },
+          };
+          await client.workflows.triggers.create<CustomizableInputWorkflow>({
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error customizable must be a boolean
+              customizable: { customizable: "incorrect type" },
+            },
+          });
+          assert(true);
+        },
+      );
+
+      await t.step(
+        "catches if customizable is false",
+        async () => {
+          const _: Trigger<CustomizableInputWorkflow> = {
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error customizable must be true
+              customizable: { customizable: false },
+            },
+          };
+          await client.workflows.triggers.create<CustomizableInputWorkflow>({
+            name: "TEST",
+            type: "shortcut",
+            workflow: "#/workflows/example",
+            inputs: {
+              //@ts-expect-error customizable must be true
+              customizable: { customizable: false },
+            },
+          });
+          assert(true);
+        },
+      );
     });
 
     await t.step("handles workflow with a mix of inputs", async (t) => {


### PR DESCRIPTION
###  Summary
Introducing a new WorkflowInput type: `customizable`.

This is part of the [Button starting workflow ](https://corp.quip.com/Jx1JAnkMqaCM#ZIDAAAZVFO2) effort and will allow Next-gen developers to include a `customizable_value` as an input type. We are following Option 2 in the [Link triggers with input tech spec](https://corp.quip.com/6FHSAndrII4w/Options-for-allowing-link-triggers-w-inputs).

Here is the major change in this PR:
```
interface BaseWorkflowInputs {
  /** @description The value of the workflow input parameter during workflow execution. Template variables may be used here. */
  value?: unknown;
  /** @description Set to `true` to allow the input parameter to be customizable, meaning its value is provided separately from the trigger. */
  customizable?: true;
}

type WorkflowInputValue = BaseWorkflowInputs & {
  // deno-lint-ignore no-explicit-any
  value: any;
  customizable_value?: never;
};

type WorkflowInputCustomizableValue = BaseWorkflowInputs & {
  customizable_value: true;
  value?: never;
};

/** The structure that must be provided to the workflow input to pass a value */
type WorkflowInput = WorkflowInputValue | WorkflowInputCustomizableValue;
```

A key thing to point out is that we are allowing either `value` or `customizable` but NOT both.

Tests have been added.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
