### PR TITLE
adding types for external.auth.get

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -219,6 +219,22 @@ Deno.test("SlackAPI class", async (t) => {
         mf.reset();
       },
     );
+
+    await t.step(
+      "should allow for typed method calls for external auth",
+      async () => {
+        mf.mock("POST@/api/apps.auth.external.get", () => {
+          return new Response('{"ok":true, "external_token": "abcd"}');
+        });
+        const TestExternalAuthId = {
+          external_token_id: "ET12345",
+        };
+        const res = await client.apps.auth.external.get(TestExternalAuthId);
+        assertEquals(res.ok, true);
+        assertEquals(res.external_token, "abcd");
+        mf.reset();
+      },
+    );
   });
 
   mf.uninstall();

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -80,8 +80,9 @@ export function serializeData(data: Record<string, unknown>): URLSearchParams {
     // Skip properties with undefined values.
     if (value === undefined) return;
 
-    const serializedValue: string =
-      (typeof value !== "string" ? JSON.stringify(value) : value);
+    const serializedValue: string = typeof value !== "string"
+      ? JSON.stringify(value)
+      : value;
     encodedData[key] = serializedValue;
   });
 

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -156,6 +156,32 @@ export type AppsDatastoreDelete = {
   ): Promise<DatastoreDeleteResponse<Schema>>;
 };
 
+// apps.auth Types
+
+type AppsAuthExternalGetArgs = {
+  /** @description The id of a specified external token */
+  external_token_id: string;
+};
+
+type AppsAuthExternalGetResponse =
+  | AppsAuthExternalGetSuccessfulResponse
+  | AppsAuthExternalGetFailedResponse;
+type AppsAuthExternalGetSuccessfulResponse = BaseResponse & {
+  ok: true;
+  /** @description The actual external token */
+  external_token: string;
+};
+
+type AppsAuthExternalGetFailedResponse = BaseResponse & {
+  ok: false;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type AppsAuthExternalGet = {
+  (args: AppsAuthExternalGetArgs): Promise<AppsAuthExternalGetResponse>;
+};
+
 export type TypedAppsMethodTypes = {
   apps: {
     datastore: {
@@ -163,6 +189,11 @@ export type TypedAppsMethodTypes = {
       put: AppsDatastorePut;
       query: AppsDatastoreQuery;
       delete: AppsDatastoreDelete;
+    };
+    auth: {
+      external: {
+        get: AppsAuthExternalGet;
+      };
     };
   };
 };

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -174,6 +174,7 @@ type AppsAuthExternalGetSuccessfulResponse = BaseResponse & {
 
 type AppsAuthExternalGetFailedResponse = BaseResponse & {
   ok: false;
+  external_token?: never;
   // deno-lint-ignore no-explicit-any
   [otherOptions: string]: any;
 };

--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -16,6 +16,7 @@ export const methodsWithCustomTypes = [
   "apps.datastore.get",
   "apps.datastore.put",
   "apps.datastore.query",
+  "apps.auth.external.get",
   "chat.postMessage",
   "functions.completeSuccess",
   "functions.completeError",

--- a/src/typed-method-types/typed-method-tests.ts
+++ b/src/typed-method-types/typed-method-tests.ts
@@ -8,6 +8,7 @@ Deno.test("Custom Type Methods are valid functions", () => {
   assertEquals(typeof client.apps.datastore.get, "function");
   assertEquals(typeof client.apps.datastore.put, "function");
   assertEquals(typeof client.apps.datastore.query, "function");
+  assertEquals(typeof client.apps.auth.external.get, "function");
   assertEquals(typeof client.workflows.triggers.create, "function");
   assertEquals(typeof client.workflows.triggers.list, "function");
   assertEquals(typeof client.workflows.triggers.update, "function");


### PR DESCRIPTION
###  Summary

We are trying to add a typeahead for app.auth.external.get API. This endpoint is used by developers who want to fetch an external token  from Backend using an `external_token_id`.
 
https://jira.tinyspeck.com/browse/PAX-11446

**Relevant discussion:**
https://slack-pde.slack.com/archives/C02TBKP7CAZ/p1661462028102829?thread_ts=1661456017.960299&cid=C02TBKP7CAZ

**Tests:**

- New tests
- Manually tested in VSCode

<img width="756" alt="Screen Shot 2023-02-02 at 4 31 16 PM" src="https://user-images.githubusercontent.com/98924772/216454174-f5f9f5c2-d600-4194-bf9f-c239bc5c2daf.png">

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
