### PR TITLE
Adding more typeaheads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 scripts/api_spec.json
 .coverage
+deno.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 scripts/api_spec.json
 .coverage
-deno.lock

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -235,6 +235,22 @@ Deno.test("SlackAPI class", async (t) => {
         mf.reset();
       },
     );
+
+    await t.step(
+      "should allow for typed method calls for external auth with force_refresh",
+      async () => {
+        mf.mock("POST@/api/apps.auth.external.get", () => {
+          return new Response('{"ok":true, "external_token": "abcd"}');
+        });
+        const res = await client.apps.auth.external.get({
+          external_token_id: "ET12345",
+          force_refresh: true,
+        });
+        assertEquals(res.ok, true);
+        assertEquals(res.external_token, "abcd");
+        mf.reset();
+      },
+    );
   });
 
   mf.uninstall();

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -251,6 +251,20 @@ Deno.test("SlackAPI class", async (t) => {
         mf.reset();
       },
     );
+
+    await t.step(
+      "should allow for typed method calls for external auth delete method",
+      async () => {
+        mf.mock("POST@/api/apps.auth.external.delete", () => {
+          return new Response('{"ok":true}');
+        });
+        const res = await client.apps.auth.external.delete({
+          external_token_id: "ET12345",
+        });
+        assertEquals(res.ok, true);
+        mf.reset();
+      },
+    );
   });
 
   mf.uninstall();

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -161,6 +161,9 @@ export type AppsDatastoreDelete = {
 type AppsAuthExternalGetArgs = {
   /** @description The id of a specified external token */
   external_token_id: string;
+
+  /** @description always refresh the token before fetching */
+  force_refresh?: boolean;
 };
 
 type AppsAuthExternalGetResponse =

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -186,6 +186,31 @@ type AppsAuthExternalGet = {
   (args: AppsAuthExternalGetArgs): Promise<AppsAuthExternalGetResponse>;
 };
 
+// AppsAuthExternalDelete
+
+type AppsAuthExternalDeleteArgs = {
+  /** @description The id of a specified external token */
+  external_token_id: string;
+};
+
+type AppsAuthExternalDeleteSuccessfulResponse = BaseResponse & {
+  ok: true;
+};
+
+type AppsAuthExternalDeleteFailedResponse = BaseResponse & {
+  ok: false;
+  // deno-lint-ignore no-explicit-any
+  [otherOptions: string]: any;
+};
+
+type AppsAuthExternalDeleteResponse =
+  | AppsAuthExternalDeleteSuccessfulResponse
+  | AppsAuthExternalDeleteFailedResponse;
+
+type AppsAuthExternalDelete = {
+  (args: AppsAuthExternalDeleteArgs): Promise<AppsAuthExternalDeleteResponse>;
+};
+
 export type TypedAppsMethodTypes = {
   apps: {
     datastore: {
@@ -197,6 +222,7 @@ export type TypedAppsMethodTypes = {
     auth: {
       external: {
         get: AppsAuthExternalGet;
+        delete: AppsAuthExternalDelete;
       };
     };
   };

--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -17,6 +17,7 @@ export const methodsWithCustomTypes = [
   "apps.datastore.put",
   "apps.datastore.query",
   "apps.auth.external.get",
+  "apps.auth.external.delete",
   "chat.postMessage",
   "functions.completeSuccess",
   "functions.completeError",

--- a/src/typed-method-types/typed-method-tests.ts
+++ b/src/typed-method-types/typed-method-tests.ts
@@ -9,6 +9,7 @@ Deno.test("Custom Type Methods are valid functions", () => {
   assertEquals(typeof client.apps.datastore.put, "function");
   assertEquals(typeof client.apps.datastore.query, "function");
   assertEquals(typeof client.apps.auth.external.get, "function");
+  assertEquals(typeof client.apps.auth.external.delete, "function");
   assertEquals(typeof client.workflows.triggers.create, "function");
   assertEquals(typeof client.workflows.triggers.list, "function");
   assertEquals(typeof client.workflows.triggers.update, "function");


### PR DESCRIPTION
###  Summary

We are trying to add a typeahead for app.auth.external.get API. This endpoint is used by developers who want to fetch an external token  from Backend using an `external_token_id`.
 
https://jira.tinyspeck.com/browse/PAX-11446

**Relevant discussion:**
https://slack-pde.slack.com/archives/C02TBKP7CAZ/p1661462028102829?thread_ts=1661456017.960299&cid=C02TBKP7CAZ

**Tests:**

- New tests
- Manually tested in VSCode
<img width="917" alt="Screenshot 2023-02-06 at 11 09 18 AM" src="https://user-images.githubusercontent.com/98924772/217023802-fd2c8fe1-a42c-4d0a-a5f0-cca59b97af5b.png">


### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
