### PR TITLE
add apps.datastore.update route

### DIFF
--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -51,6 +51,36 @@ export type DatastorePutResponse<
     item: DatastoreItem<Schema>;
   };
 
+export type DatastoreUpdateArgs<
+  Schema extends DatastoreSchema,
+> =
+  & BaseMethodArgs
+  & {
+    /**
+     * @description The name of the datastore
+     */
+    datastore: Schema["name"];
+    /**
+     * @description The item to store
+     */
+    item: DatastoreItem<Schema>;
+  };
+
+export type DatastoreUpdateResponse<
+  Schema extends DatastoreSchema,
+> =
+  & BaseResponse
+  & {
+    /**
+     * @description The name of the datastore
+     */
+    datastore: Schema["name"];
+    /**
+     * @description The item that was stored
+     */
+    item: DatastoreItem<Schema>;
+  };
+
 export type DatastoreGetArgs<
   Schema extends DatastoreSchema,
 > =
@@ -148,6 +178,11 @@ export type AppsDatastorePut = {
     args: DatastorePutArgs<Schema>,
   ): Promise<DatastorePutResponse<Schema>>;
 };
+export type AppsDatastoreUpdate = {
+  <Schema extends DatastoreSchema>(
+    args: DatastoreUpdateArgs<Schema>,
+  ): Promise<DatastoreUpdateResponse<Schema>>;
+};
 export type AppsDatastoreQuery = {
   <Schema extends DatastoreSchema>(
     args: DatastoreQueryArgs<Schema>,
@@ -219,6 +254,7 @@ export type TypedAppsMethodTypes = {
     datastore: {
       get: AppsDatastoreGet;
       put: AppsDatastorePut;
+      update: AppsDatastoreUpdate;
       query: AppsDatastoreQuery;
       delete: AppsDatastoreDelete;
     };

--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -15,6 +15,7 @@ export const methodsWithCustomTypes = [
   "apps.datastore.delete",
   "apps.datastore.get",
   "apps.datastore.put",
+  "apps.datastore.update",
   "apps.datastore.query",
   "apps.auth.external.get",
   "apps.auth.external.delete",

--- a/src/typed-method-types/typed-method-tests.ts
+++ b/src/typed-method-types/typed-method-tests.ts
@@ -7,6 +7,7 @@ Deno.test("Custom Type Methods are valid functions", () => {
   assertEquals(typeof client.apps.datastore.delete, "function");
   assertEquals(typeof client.apps.datastore.get, "function");
   assertEquals(typeof client.apps.datastore.put, "function");
+  assertEquals(typeof client.apps.datastore.update, "function");
   assertEquals(typeof client.apps.datastore.query, "function");
   assertEquals(typeof client.apps.auth.external.get, "function");
   assertEquals(typeof client.apps.auth.external.delete, "function");


### PR DESCRIPTION
###  Summary

As part of the preparation for datastore general availability, we want to fix a potential confusing behavior of the `datastore.put` method, where it actually behaves more like a field level update (aka patch). The addition of a `apps.datastore.update` route provides a migration path for users when we start handling a `put` as create or replace.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
