### PR TITLE
Datastores only require primary key, all other attributes are optional

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -205,7 +205,7 @@ Deno.test("SlackAPI class", async (t) => {
             email: "string",
           },
           primary_key: "id",
-        };
+        } as const; // casted as const to validate primary_key requirement
 
         const res = await client.apps.datastore.put<typeof TestDatastore>({
           datastore: "test",

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -3,5 +3,5 @@ export {
   assertEquals,
   assertExists,
   assertRejects,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.132.0/testing/asserts.ts";
 export * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -3,5 +3,5 @@ export {
   assertEquals,
   assertExists,
   assertRejects,
-} from "https://deno.land/std@0.132.0/testing/asserts.ts";
+} from "https://deno.land/std@0.152.0/testing/asserts.ts";
 export * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -13,10 +13,13 @@ export type DatastoreSchema = {
   primary_key: string;
 };
 
-export type DatastoreItem<Schema extends DatastoreSchema> = {
+export type DatastoreItem<Schema extends DatastoreSchema> =
   // deno-lint-ignore no-explicit-any
-  [k in keyof Schema["attributes"]]: any;
-};
+  & Record<Schema["primary_key"], any>
+  & {
+    // deno-lint-ignore no-explicit-any
+    [k in keyof Schema["attributes"]]?: any;
+  };
 
 export type DatastorePutArgs<
   Schema extends DatastoreSchema,


### PR DESCRIPTION
###  Summary

Update the `DatastoreItem` to only assume that the `primary_key` is provided. This impacts the `put` call's arguments, and the response for the `put`, `get`, and `query` calls.

#### Testing

1. Point your `import_map.json`'s local API version to this one
```json
{
  "imports": {
    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.5.1/",
    "deno-slack-api/": "https://raw.githubusercontent.com/slackapi/deno-slack-api/neil-datastores-only-require-primary-key/src/mod.ts"
  }
}
```
2. Define a datastore
```ts
export const MyStore = DefineDatastore({
  name: "test",
  attributes: {
    id: { type: Schema.types.string },
    email: { type: Schema.types.string },
  },
  primary_key: "id",
});
```
3. Import `SlackAPI` from the API and instantiate your own client (using the argument from `SlackFunction` will lead to issues)
```ts
import { SlackAPI } from "deno-slack-api/mod.ts";
...
export default SlackFunction(
  GreetingFunctionDefinition,
  async ({ inputs, token }) => {
    const client = SlackAPI(token);
    ...
);
```
4. Make a client call and don't pass the `primary_key` to see an error
```ts
const resp = await client.apps.datastore.put<typeof MyStore.definition>({
      datastore: "test",
      item: {
        // id: "hi", the primary key is commented out
        email: "hi",
      },
    });
```
5. Make a client call and don't pass the `primary_key` to see an error
```ts
const resp = await client.apps.datastore.put<typeof MyStore.definition>({
      datastore: "test",
      item: {
        id: "hi",
      },
    });
```
6. Validate that the item properties on the response are optional
```ts
resp.item.id // this is required
resp.item.email // this is optional
```

Also do this for `client.apps.datastore.get` and `client.apps.datastore.query` responses.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
