### PR TITLE
Export `DatastoreItem` and make Datastore item properties required in responses 

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,6 @@
 import { BaseSlackAPIClient } from "./base-client.ts";
 import { SlackAPIOptions } from "./types.ts";
 import { ProxifyAndTypeClient } from "./api-proxy.ts";
-export type { OptionalDatastoreItem } from "./typed-method-types/apps.ts";
 
 export const SlackAPI = (token: string, options: SlackAPIOptions = {}) => {
   // Create our base client instance

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,7 @@
 import { BaseSlackAPIClient } from "./base-client.ts";
 import { SlackAPIOptions } from "./types.ts";
 import { ProxifyAndTypeClient } from "./api-proxy.ts";
+export type { OptionalDatastoreItem } from "./typed-method-types/apps.ts";
 
 export const SlackAPI = (token: string, options: SlackAPIOptions = {}) => {
   // Create our base client instance

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -54,7 +54,7 @@ export type DatastorePutResponse<
     /**
      * @description The item that was stored
      */
-    // TODO: Remove Required utility
+    // TODO: [brk-chg] Remove Required utility
     item: Required<DatastoreItem<Schema>>;
   };
 
@@ -85,7 +85,7 @@ export type DatastoreUpdateResponse<
     /**
      * @description The item that was stored
      */
-    // TODO: Remove Required Utility
+    // TODO: [brk-chg] Remove Required Utility
     item: Required<DatastoreItem<Schema>>;
   };
 
@@ -117,7 +117,7 @@ export type DatastoreGetResponse<
     /**
      * @description The retreived item
      */
-    // TODO: Remove Required Utility
+    // TODO: [brk-chg] Remove Required Utility
     item: Required<DatastoreItem<Schema>>;
   };
 
@@ -149,7 +149,7 @@ export type DatastoreQueryResponse<
     /**
      * @description The items matching your query
      */
-    // TODO: Remove Required Utility
+    // TODO: [brk-chg] Remove Required Utility
     items: Required<DatastoreItem<Schema>>[];
   };
 

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -13,12 +13,6 @@ export type DatastoreSchema = {
   primary_key: string;
 };
 
-/**
- * @deprecated This type is temporarily available for migration
- */
-export type OptionalDatastoreItem<Schema extends DatastoreSchema> =
-  DatastoreItem<Schema>;
-
 export type DatastoreItem<Schema extends DatastoreSchema> =
   // deno-lint-ignore no-explicit-any
   & Record<Schema["primary_key"], any>

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -13,6 +13,12 @@ export type DatastoreSchema = {
   primary_key: string;
 };
 
+/**
+ * @deprecated This type is temporarily available for migration
+ */
+export type OptionalDatastoreItem<Schema extends DatastoreSchema> =
+  DatastoreItem<Schema>;
+
 export type DatastoreItem<Schema extends DatastoreSchema> =
   // deno-lint-ignore no-explicit-any
   & Record<Schema["primary_key"], any>
@@ -48,7 +54,8 @@ export type DatastorePutResponse<
     /**
      * @description The item that was stored
      */
-    item: DatastoreItem<Schema>;
+    // TODO: Remove Required utility
+    item: Required<DatastoreItem<Schema>>;
   };
 
 export type DatastoreUpdateArgs<
@@ -78,7 +85,8 @@ export type DatastoreUpdateResponse<
     /**
      * @description The item that was stored
      */
-    item: DatastoreItem<Schema>;
+    // TODO: Remove Required Utility
+    item: Required<DatastoreItem<Schema>>;
   };
 
 export type DatastoreGetArgs<
@@ -109,7 +117,8 @@ export type DatastoreGetResponse<
     /**
      * @description The retreived item
      */
-    item: DatastoreItem<Schema>;
+    // TODO: Remove Required Utility
+    item: Required<DatastoreItem<Schema>>;
   };
 
 export type DatastoreQueryArgs<
@@ -140,7 +149,8 @@ export type DatastoreQueryResponse<
     /**
      * @description The items matching your query
      */
-    items: DatastoreItem<Schema>[];
+    // TODO: Remove Required Utility
+    items: Required<DatastoreItem<Schema>>[];
   };
 
 export type DatastoreDeleteArgs<

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { TypedSlackAPIMethodsType } from "./typed-method-types/mod.ts";
 import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
+export type { DatastoreItem } from "./typed-method-types/apps.ts";
 
 export type {
   /**


### PR DESCRIPTION
###  Summary

Datastore calls continue to treat response item properties as non-undefined, but export `DatastoreItem` for migration purposes with casting.

Datastore call arguments still treat non `primary_key` properties as optional.

This allows a migration path so that any dev who wants to handle the case where their responses will be undefined can cast their resulting items like
```ts
const responseItem = putResponse.item as DatastoreItem<
    typeof MyStore.definition
>;
```

### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
