### PR TITLE
Integrate a better CLI utility for generating code coverage reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 scripts/api_spec.json
 .coverage
+lcov.info

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -25,7 +25,7 @@
   },
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test",
-    "coverage": "deno test --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test --exclude=src/generated .coverage"
+    "coverage": "deno test --coverage=.coverage && deno coverage --exclude=fixtures --exclude=test --exclude=src/generated --lcov --output=lcov.info .coverage && deno run --allow-read https://deno.land/x/code_coverage@0.2.0/cli.ts"
   },
   "lock": false
 }


### PR DESCRIPTION
###  Summary

Small tweak to the coverage task, I think the output is much nicer and it also gives you a project-wide total (which the built-in deno CLI `deno coverage` tool does not):

<img width="1427" alt="Screenshot 2023-03-01 at 12 45 50 PM" src="https://user-images.githubusercontent.com/52645/222223859-b2e46151-570b-4be5-a4bb-13d41b85f30a.png">
