### PR TITLE
Remove deprecated features

### DIFF
--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -48,8 +48,7 @@ export type DatastorePutResponse<
     /**
      * @description The item that was stored
      */
-    // TODO: [brk-chg] Remove Required utility
-    item: Required<DatastoreItem<Schema>>;
+    item: DatastoreItem<Schema>;
   };
 
 export type DatastoreUpdateArgs<
@@ -79,8 +78,7 @@ export type DatastoreUpdateResponse<
     /**
      * @description The item that was stored
      */
-    // TODO: [brk-chg] Remove Required Utility
-    item: Required<DatastoreItem<Schema>>;
+    item: DatastoreItem<Schema>;
   };
 
 export type DatastoreGetArgs<
@@ -111,8 +109,7 @@ export type DatastoreGetResponse<
     /**
      * @description The retreived item
      */
-    // TODO: [brk-chg] Remove Required Utility
-    item: Required<DatastoreItem<Schema>>;
+    item: DatastoreItem<Schema>;
   };
 
 export type DatastoreQueryArgs<
@@ -143,8 +140,7 @@ export type DatastoreQueryResponse<
     /**
      * @description The items matching your query
      */
-    // TODO: [brk-chg] Remove Required Utility
-    items: Required<DatastoreItem<Schema>>[];
+    items: DatastoreItem<Schema>[];
   };
 
 export type DatastoreDeleteArgs<

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,6 @@ import { SlackAPIMethodsType } from "./generated/method-types/mod.ts";
 export type { DatastoreItem } from "./typed-method-types/apps.ts";
 
 export type {
-  /**
-   * @deprecated Use Trigger instead
-   */
-  ValidTriggerTypes,
   ValidTriggerTypes as Trigger,
 } from "./typed-method-types/workflows/triggers/mod.ts";
 


### PR DESCRIPTION
###  Summary

Remove features that have the `@deprecated` tag or that were part of our breaking changes announcement.
This includes removing the deprecated `ValidTriggerTypes` named export and properly reflecting that the only attribute that's assured (required) in the response is the `primary_key`. The work to make those attributes optional in the client call was done in a previous PR.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
