### PR TITLE
Update slack naming

### DIFF
--- a/docs/triggers/event-triggers.md
+++ b/docs/triggers/event-triggers.md
@@ -1,17 +1,17 @@
-## Event Triggers
+## Event triggers
 
-An Event Trigger is a Trigger that activates when a specific event occurs within the Slack client. Event Triggers can activate on either workspace,
-or channel level events, and each specific event type has its own required object parameters that need to be filled. An event Trigger at the highest
-level includes the common Trigger parameters along with a required input parameter and an event parameter: 
+An event trigger is a trigger that activates when a specific event occurs within the Slack client. Event triggers can activate on either workspace,
+or channel level events, and each specific event type has its own required object parameters that need to be filled. An event trigger at the highest
+level includes the common trigger parameters along with a required input parameter and an event parameter:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
 | `event`           | Yes            | An event object with information about the activation event          |
 
-### Event Types
+### Event types
 
-An `event_type` is a string which corresponds to an event in the Slack Client. These `event_type`s can be set on a Trigger to activate a Workflow.
-Currently, events are separated into two categories, Workspace level events, and Channel level events. Workspace level events are events that affect the entire workspace, regardless of channel or specific chat id. Channel level events listen in on specific channels and only activate when the event happens inside of that channel. Each of these require a separate payload which can be found defined in the section [below](#the-event-object). 
+An `event_type` is a string which corresponds to an event in the Slack client. These `event_type`s can be set on a trigger to activate a workflow.
+Currently, events are separated into two categories, Workspace level events, and Channel level events. Workspace level events are events that affect the entire workspace, regardless of channel or specific chat id. Channel level events listen in on specific channels and only activate when the event happens inside of that channel. Each of these require a separate payload which can be found defined in the section [below](#the-event-object).
 The following is a list of event types along with their category:
 
 | Event Name                       | Event String                | Category      | Notes       | Link    |  Payload     |
@@ -42,7 +42,7 @@ The following is a list of event types along with their category:
 
 ### Event Configuration
 
-Event Trigger must contain an Event configuration object, which specifies the details of the Event that will activate the Trigger. The Event configuration object has the following attributes: 
+Event trigger must contain an Event configuration object, which specifies the details of the Event that will activate the trigger. The Event configuration object has the following attributes:
 
 | Parameter name    | Required?     | Description                                                             |
 | ------------------|:-------------:| ------------------------------------------------------------------------|
@@ -52,12 +52,12 @@ Event Trigger must contain an Event configuration object, which specifies the de
 | `channel_ids`       | Sometimes     | An array of `channel_id` strings that specifies which channels to listen for events (required for channel level events)  |
 | `metadata_event_type`       | Sometimes     | Required for metadata events, string corresponding to the event type |
 
+### Context data availability
 
-### Context Data Availability
-
-The `inputs` parameter has access to context information from when the Trigger is activated. Each event_type has access to its own specific data parameters which can be found below:
+The `inputs` parameter has access to context information from when the trigger is activated. Each event_type has access to its own specific data parameters which can be found below:
 
 #### reaction_added
+
 ```json
 "data": {             
   "event_type": "slack#/events/reaction_added",             
@@ -69,6 +69,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### message_metadata_posted
+
 ```json
 "data": {             
   "event_type": "slack#/events/message_metadata_posted",              
@@ -90,6 +91,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### user_joined_channel
+
 ```json
 "data": {             
   "event_type": "slack#/events/user_joined_channel",            
@@ -101,6 +103,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### dnd_status_updated
+
 ```json
 "data": {             
   "event_type": "slack#/events/user_updated_dnd",             
@@ -114,6 +117,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_created
+
 ```json
 "data": {             
   "event_type": "slack#/events/channel_created",             
@@ -126,6 +130,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### user_joined_team
+
 ```json
 "data": {             
   "event_type": "slack#/events/user_joined_team",              
@@ -140,7 +145,9 @@ The `inputs` parameter has access to context information from when the Trigger i
   }            
 }
 ```
+
 #### emoji_changed
+
 ```json
 "data": {             
   "event_type": "slack#/events/emoji_changed",             
@@ -151,6 +158,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### user_left_channel
+
 ```json
 "data": {             
   "event_type": "slack#/events/user_left_channel",             
@@ -159,7 +167,9 @@ The `inputs` parameter has access to context information from when the Trigger i
   "channel_type" : "public/private/im/mpim", //channel type can be one of these 4 values, either "public", "private", "im", or "mpim"        
 }
 ```
+
 #### reaction_removed
+
 ```json
 "data": {             
   "event_type": "slack#/events/reaction_removed",             
@@ -171,6 +181,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_deleted
+
 ```json
 "data": {             
   "event_type": "slack#/events/channel_deleted",              
@@ -182,6 +193,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_renamed
+
 ```json
 "data": {             
   "event_type": "slack#/events/channel_renamed",             
@@ -193,6 +205,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### pin_added
+
 ```json
 "data": {             
   "event_type": "slack#/events/pin_added",              
@@ -205,6 +218,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### pin_removed
+
 ```json
 "data": {              
   "event_type": "slack#/events/pin_removed",              
@@ -217,6 +231,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_archived
+
 ```json
 "data": {             
   "event_type": "slack#/events/channel_archived",             
@@ -227,6 +242,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_unarchived
+
 ```json
 "data": {              
   "event_type": "slack#/events/channel_unarchived",             
@@ -238,6 +254,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_shared
+
 ```json
 "data": {              
   "event_type": "slack#/events/channel_shared",              
@@ -249,6 +266,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### channel_unshared
+
 ```json
 "data": {              
   "event_type": "slack#/events/channel_unshared",              
@@ -261,6 +279,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### app_mentioned
+
 ```json
 "data": {              
   "event_type": "slack#/events/app_mentioned",              
@@ -273,6 +292,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### shared_channel_invite_accepted
+
 ```json
 "data": {
   "event_type": "slack#/events/shared_channel_invite_accepted",
@@ -327,6 +347,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### shared_channel_invite_approved
+
 ```json
 "data": {    
   "event_type": "slack#/events/shared_channel_invite_approved",    
@@ -381,6 +402,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### shared_channel_invite_declined
+
 ```json
 "data": {    
   "event_type": "slack#/events/shared_channel_invite_approved",    
@@ -435,6 +457,7 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 #### shared_channel_invite_received
+
 ```json
 "data": {  
   "event_type": "slack#/events/shared_channel_invite_received",  
@@ -468,8 +491,11 @@ The `inputs` parameter has access to context information from when the Trigger i
 ```
 
 ## Usage
-The examples below are sample Trigger objects which can be used to create Triggers in the [CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli).
-### Channel Level Trigger
+
+The examples below are sample trigger objects which can be used to create triggers in the [CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli).
+
+### Channel level trigger
+
 ```ts
 const trigger: Trigger = {
   type: "event",
@@ -488,7 +514,8 @@ const trigger: Trigger = {
 };
 ```
 
-### Workspace Level Trigger
+### Workspace level trigger
+
 ```ts
 const trigger: Trigger = {
   type: "event",
@@ -506,7 +533,8 @@ const trigger: Trigger = {
 }
 ```
 
-### MessagePosted Trigger
+### MessagePosted trigger
+
 ```ts
 const trigger: Trigger = {
   type: "event",
@@ -531,7 +559,8 @@ const trigger: Trigger = {
 }
 ```
 
-### Message Metadata Trigger
+### Message metadata trigger
+
 ```ts
 const trigger: Trigger = {
   type: "event",
@@ -550,7 +579,9 @@ const trigger: Trigger = {
   },
 }
 ```
-### Example Response
+
+### Example response
+
 ```ts
 {
   ok: true,

--- a/docs/triggers/event-triggers.md
+++ b/docs/triggers/event-triggers.md
@@ -42,7 +42,7 @@ The following is a list of event types along with their category:
 
 ### Event Configuration
 
-Event trigger must contain an Event configuration object, which specifies the details of the Event that will activate the trigger. The Event configuration object has the following attributes:
+Event trigger must contain an event configuration object, which specifies the details of the event that will activate the trigger. The event configuration object has the following attributes:
 
 | Parameter name    | Required?     | Description                                                             |
 | ------------------|:-------------:| ------------------------------------------------------------------------|

--- a/docs/triggers/link-triggers.md
+++ b/docs/triggers/link-triggers.md
@@ -1,6 +1,6 @@
 ## Link triggers
 
-A link trigger is an interactive trigger that activates when a link is clicked in the Slack client. When a link trigger is created, its API response returns a `shortcut_url` which can be used in Slack to show a button. Clicking on this button will activate the associated Workflow. A link trigger
+A link trigger is an interactive trigger that activates when a link is clicked in the Slack client. When a link trigger is created, its API response returns a `shortcut_url` which can be used in Slack to show a button. Clicking on this button will activate the associated workflow. A link trigger
 includes the common [trigger attributes](./trigger-basics.md#trigger-types) along with an optional shortcut parameter:
 
 | Parameter name  | Required?     | Description                                                          |

--- a/docs/triggers/link-triggers.md
+++ b/docs/triggers/link-triggers.md
@@ -1,15 +1,15 @@
-## Link Triggers
+## Link triggers
 
-A Link Trigger is an interactive Trigger that activates when a link is clicked in the Slack client. When a Link Trigger is created, its API response returns a `shortcut_url` which can be used in Slack to show a button. Clicking on this button will activate the associated Workflow. A Link Trigger
-includes the common [Trigger attributes](./trigger-basics.md#trigger-types) along with an optional shortcut parameter: 
+A link trigger is an interactive trigger that activates when a link is clicked in the Slack client. When a link trigger is created, its API response returns a `shortcut_url` which can be used in Slack to show a button. Clicking on this button will activate the associated Workflow. A link trigger
+includes the common [trigger attributes](./trigger-basics.md#trigger-types) along with an optional shortcut parameter:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
 | `shortcut`        | No            | Contains information about the [button text](#shortcut-object) of the shortcut          |
 
-### Shortcut Configuration
+### Shortcut configuration
 
-A Link Trigger can contain an optional `shortcut` configuration object which specifies additional details about the link. Currently, the `shortcut` object is used to specify the button text of the link associated with the Trigger and has the following shape:
+A link trigger can contain an optional `shortcut` configuration object which specifies additional details about the link. Currently, the `shortcut` object is used to specify the button text of the link associated with the trigger and has the following shape:
 
 ```ts
   shortcut?: {
@@ -17,20 +17,21 @@ A Link Trigger can contain an optional `shortcut` configuration object which spe
   };
 ```
 
-### Context Data Availability
-The `data` context parameters available to a Shortcut Trigger are as follows:
+### Context data vailability
+
+The `data` context parameters available to a Shortcut trigger are as follows:
 
 | Parameter name  | type     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `data.user_id`        | string            | A unique identifier for the Slack user who invoked the Trigger         |
-| `data.channel_id`        | string            | A unique identifier for the channel where the Trigger was invoked         |
+| `data.user_id`        | string            | A unique identifier for the Slack user who invoked the trigger         |
+| `data.channel_id`        | string            | A unique identifier for the channel where the trigger was invoked         |
 | `data.interactivity`        | object            | See [Block Kit interactivity](https://api.dev.slack.com/future/triggers/future/block-events)|
-| `data.location`        | string            | Where the Trigger was invoked. Can be `message` or `bookmark`|
-| `data.message_ts`        | string            | A unique UNIX timestamp in seconds indicating when the Trigger-invoking message was sent|
-| `data.user`        | object            | An object containing a `user_id` and a `secret` that can be used to identify and validate the specific user who invoked the Trigger|
-| `data.action_id`        | string            | A unique identifier for the action that invoked the Trigger. See [Block Kit interactivity](https://api.dev.slack.com/future/triggers/future/block-events) |
-| `data.block_id`        | string            | A unique identifier for the block where the Trigger was invoked. See [Block Kit interactivity](https://api.dev.slack.com/future/triggers/future/block-events)|
-| `data.bookmark_id`        | string            | A unique identifier for the bookmark where the Trigger was invoked|
+| `data.location`        | string            | Where the trigger was invoked. Can be `message` or `bookmark`|
+| `data.message_ts`        | string            | A unique UNIX timestamp in seconds indicating when the trigger-invoking message was sent|
+| `data.user`        | object            | An object containing a `user_id` and a `secret` that can be used to identify and validate the specific user who invoked the trigger|
+| `data.action_id`        | string            | A unique identifier for the action that invoked the trigger. See [Block Kit interactivity](https://api.dev.slack.com/future/triggers/future/block-events) |
+| `data.block_id`        | string            | A unique identifier for the block where the trigger was invoked. See [Block Kit interactivity](https://api.dev.slack.com/future/triggers/future/block-events)|
+| `data.bookmark_id`        | string            | A unique identifier for the bookmark where the trigger was invoked|
 
 The data context can be used in the input parameter as follows:
 
@@ -43,11 +44,13 @@ The data context can be used in the input parameter as follows:
  }
 }
 ```
+
 ## Usage
-Below are some usage examples of `ShortcutTrigger` objects which can be used in a .ts file to create a `shortcut` trigger through the [Slack CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli), alternatively this object could be passed into a 
+
+Below are some usage examples of `ShortcutTrigger` objects which can be used in a .ts file to create a `shortcut` trigger through the [Slack CLI](./trigger-basics.md/#creating-triggers-using-the-slack-cli), alternatively this object could be passed into a
 `client.workflows.triggers.create` method to achieve the same effect at [runtime](./trigger-basics.md/#creating-triggers-in-the-runtime-environment).
 
-### Example Configured Shortcut Trigger
+### Example configured shortcut trigger
 
 ```ts
 const trigger: ShortcutTrigger = {
@@ -68,7 +71,7 @@ const trigger: ShortcutTrigger = {
 export default trigger;
 ```
 
-### Example Shortcut Trigger Without Shortcut Object
+### Example shortcut trigger without shortcut object
 
 ```ts
 const trigger: ShortcutTrigger = {

--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -8,7 +8,7 @@ A scheduled trigger is a trigger that activates on a set schedule, defined by a 
 
 ### Schedule configuration
 
-The `schedule` object can take the shape of either a Single Occurrence schedule or a Recurring Schedule. A Single occurrence schedule is a schedule which will only activate one time, a recurring schedule sets a schedule that will repeat on the schedule.
+The `schedule` object can take the shape of either a single occurrence schedule or a recurring schedule. A single occurrence schedule is a schedule which will only activate one time, a recurring schedule sets a schedule that will repeat on the schedule.
 
 Both Single Occurrence and Recurring Schedules have common base attributes:
 

--- a/docs/triggers/scheduled-trigger.md
+++ b/docs/triggers/scheduled-trigger.md
@@ -1,44 +1,45 @@
-## Scheduled Triggers
+## Scheduled triggers
 
-A Scheduled Trigger is a Trigger that activates on a set schedule, defined by a `schedule` parameter object. A Scheduled Trigger includes the common Trigger attributes along with a required `schedule` parameter: 
+A scheduled trigger is a trigger that activates on a set schedule, defined by a `schedule` parameter object. A scheduled trigger includes the common trigger attributes along with a required `schedule` parameter:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `schedule`        | No            | Contains information about the Trigger schedule            |
+| `schedule`        | No            | Contains information about the trigger schedule            |
 
-### Schedule Configuration
+### Schedule configuration
 
-The `schedule` object can take the shape of either a Single Occurrence schedule or a Recurring Schedule. A Single occurrence schedule is a schedule which will only activate one time, a recurring schedule sets a schedule that will repeat on the schedule. 
+The `schedule` object can take the shape of either a Single Occurrence schedule or a Recurring Schedule. A Single occurrence schedule is a schedule which will only activate one time, a recurring schedule sets a schedule that will repeat on the schedule.
 
 Both Single Occurrence and Recurring Schedules have common base attributes:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `start_time`      | Yes  |An ISO 8601 date string of when this scheduled Trigger should start (i.e. "2022-03-01T14:00:00Z")|
+| `start_time`      | Yes  |An ISO 8601 date string of when this scheduled trigger should start (i.e. "2022-03-01T14:00:00Z")|
 | `timezone`      | No  |A timezone string to use for scheduling (Defaults to UTC if left blank)|
 
-A Single occurrence schedule can be created using just these two parameters or along with these parameter explicilty mentioning once frequency type, however a recurring schedule may also include the following parameters: 
+A Single occurrence schedule can be created using just these two parameters or along with these parameter explicilty mentioning once frequency type, however a recurring schedule may also include the following parameters:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `end_time`      | No  |An ISO 8601 date string of when this scheduled Trigger should end (i.e. "2022-03-01T14:00:00Z")|
-| `occurrence_count`| No  |The maximum number of times the Trigger may run (number)|
-| `frequency`      | No  |The configurable frequency of when this Trigger will activate|
+| `end_time`      | No  |An ISO 8601 date string of when this scheduled trigger should end (i.e. "2022-03-01T14:00:00Z")|
+| `occurrence_count`| No  |The maximum number of times the trigger may run (number)|
+| `frequency`      | No  |The configurable frequency of when this trigger will activate|
 
-The `frequency` object contains information on the repeating schedule for the Trigger, it contains the following parameters:
+The `frequency` object contains information on the repeating schedule for the trigger, it contains the following parameters:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `type`      | Yes  |How often the Trigger will activate|
-| `on_days` | No  |An array of days of the week as capitalized strings i.e (["Monday", "Tuesday"]) the Trigger should activate on (not available for daily triggers)|
-| `repeats_every`      | No  |How often the Trigger will repeat, respective to the frequency type (a number, i.e every `3` days)|
+| `type`      | Yes  |How often the trigger will activate|
+| `on_days` | No  |An array of days of the week as capitalized strings i.e (["Monday", "Tuesday"]) the trigger should activate on (not available for daily triggers)|
+| `repeats_every`      | No  |How often the trigger will repeat, respective to the frequency type (a number, i.e every `3` days)|
 | `on_week_num`      | No  |The nth week of the month that a monthly schedule should activate (a number i.e. activate on the `2` week of the month|
 
-### Data Context Availability
+### Data context availability
 
-The Scheduled Trigger also has access to a data context object which includes information related to the context of the Trigger activation. This data object can be used to fill the optional input fields of the Trigger being activated. The data context parameters available to a scheduled Trigger are as follows:
+The scheduled trigger also has access to a data context object which includes information related to the context of the trigger activation. This data object can be used to fill the optional input fields of the trigger being activated. The data context parameters available to a scheduled trigger are as follows:
+
 ```ts
-  'data.user_id': string, //The user_id of the user initiating the Trigger.
+  'data.user_id': string, //The user_id of the user initiating the trigger.
 ```
 
 The data context can be used in the input parameter as follows:
@@ -55,10 +56,11 @@ The data context can be used in the input parameter as follows:
 
 ## Usage
 
-Below are some usage examples of `ScheduledTrigger` objects which can be used in a .ts file to create a `scheduled` Trigger through the Slack CLI, alternatively this object could be passed into a 
+Below are some usage examples of `ScheduledTrigger` objects which can be used in a .ts file to create a `scheduled` trigger through the Slack CLI, alternatively this object could be passed into a
 `client.workflows.triggers.create` method to achieve the same effect at runtime.
 
-### Single Occurrence Schedule
+### Single occurrence schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -71,7 +73,8 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-### Single Occurence Schedule with Time Zone
+### Single occurrence schedule with time zone
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -84,7 +87,9 @@ const schedule: ScheduledTrigger = {
     },
   };
 ```
-### Single Occurence Schedule with Time Zone and Once Frequency Type
+
+### Single occurrence schedule with time zone and once frequency type
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -99,9 +104,10 @@ const schedule: ScheduledTrigger = {
       },
     },
   };
-``` 
+```
 
-### Recurring Hourly Schedule
+### Recurring hourly schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -119,7 +125,8 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-### Recurring Daily Schedule
+### Recurring daily schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -135,7 +142,8 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-### Weekly Recurring Schedule
+### Weekly recurring schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -153,7 +161,8 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-### Monthly Recurring Schedule 
+### Monthly recurring schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -172,7 +181,8 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-### Yearly Recurring Schedule 
+### Yearly recurring schedule
+
 ```ts
 const schedule: ScheduledTrigger = {
     name: "Sample",
@@ -189,8 +199,7 @@ const schedule: ScheduledTrigger = {
   };
 ```
 
-
-### Example Response From Create API
+### Example response from create API
 
 ```ts
 {

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -1,55 +1,57 @@
-## What is a Trigger?
+## What is a trigger?
 
-A Trigger is an entry point for the execution of a [Workflow](https://api.slack.com/future/workflows). Triggers define the circumstances under which a workflow will be initiated and contain contextual information that can be
-passed along from the Trigger to a Workflow. Triggers come in different shapes and sizes, and there are four primary Trigger types which can be used to activate a Workflow.
-These four types are [Event](./event-triggers.md), [Shortcut](./shortcut-triggers.md), [Scheduled](./scheduled-trigger.md), and [Webhook](./webhook-triggers.md). Because Triggers are the entry point of a workflow, a Workflow needs to be defined before a Trigger can be written for it. API information regarding Triggers can be found at [here](https://api.slack.com/future/triggers)
+A trigger is an entry point for the execution of a [Workflow](https://api.slack.com/future/workflows). triggers define the circumstances under which a workflow will be initiated and contain contextual information that can be
+passed along from the trigger to a Workflow. Triggers come in different shapes and sizes, and there are four primary trigger types which can be used to activate a Workflow.
+These four types are [Event](./event-triggers.md), [Shortcut](./shortcut-triggers.md), [Scheduled](./scheduled-trigger.md), and [Webhook](./webhook-triggers.md). Because triggers are the entry point of a workflow, a Workflow needs to be defined before a trigger can be written for it. API information regarding triggers can be found at [here](https://api.slack.com/future/triggers)
 
-### Trigger Types
-There are currently 4 supported Trigger types, [Shortcut](shortcut-trigger.md), [Webhook](webhook-trigger.md), 
-[Event](event-trigger.md), and [Scheduled](scheduled-trigger.md). Each Trigger type has it's own configuration object, however all Triggers have parameters that are common to all Trigger types, these common parameters are as follows:
+### Trigger types
+
+There are currently 4 supported trigger types, [Shortcut](shortcut-trigger.md), [Webhook](webhook-trigger.md),
+[Event](event-trigger.md), and [Scheduled](scheduled-trigger.md). Each trigger type has it's own configuration object, however all triggers have parameters that are common to all trigger types, these common parameters are as follows:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
-| `type`            | Yes           | The type of Trigger (one of `shortcut`, `event`, `scheduled`, or `webhook`)|
-| `name`            | Yes           | The name of the Trigger                                              |
-| `description`     | No            | A description of the purpose of the Trigger                          |
-| `workflow`        | Yes           | Which Workflow the Trigger connects to                               |
+| `type`            | Yes           | The type of trigger (one of `shortcut`, `event`, `scheduled`, or `webhook`)|
+| `name`            | Yes           | The name of the trigger                                              |
+| `description`     | No            | A description of the purpose of the trigger                          |
+| `workflow`        | Yes           | Which Workflow the trigger connects to                               |
 | `inputs`          | No            | What inputs (defined in the manifest) are passed to the Workflow      |
 
-The unique configuration objects for each Trigger type can be found in their respective documents.
+The unique configuration objects for each trigger type can be found in their respective documents.
 
 ### Context Data Availability
-Each Trigger type has access to a `data` context object which includes information related to the context of the Trigger activation. This `data` object can be used to define values for `inputs` and `filters` of the Trigger being activated. Each of the four Trigger types has access to separate information which is contextual based on the Trigger type. These details will be provided in the specific article for that Trigger type.
 
+Each trigger type has access to a `data` context object which includes information related to the context of the trigger activation. This `data` object can be used to define values for `inputs` and `filters` of the trigger being activated. Each of the four trigger types has access to separate information which is contextual based on the trigger type. These details will be provided in the specific article for that trigger type.
 
-## Creating Triggers
+## Creating triggers
 
-Triggers can be created in one of two ways, either dynamically in your application at runtime, or through the Slack CLI. More details on Trigger creation can be found in the [API documentation](https://api.dev.slack.com/future/triggers#create).
+Triggers can be created in one of two ways, either dynamically in your application at runtime, or through the Slack CLI. More details on trigger creation can be found in the [API documentation](https://api.dev.slack.com/future/triggers#create).
 
 ### Creating Triggers Generic Inputs
 
-Triggers can be created or updated at runtime with an optional `WorkflowDefinition` as a generic input which utilizes the `WorkflowDefinition` object defined in the manifest to help specify what `inputs` a Trigger will require. Additional details can be found [here](trigger-generic-inputs.md).
+triggers can be created or updated at runtime with an optional `WorkflowDefinition` as a generic input which utilizes the `WorkflowDefinition` object defined in the manifest to help specify what `inputs` a trigger will require. Additional details can be found [here](trigger-generic-inputs.md).
 
-### Creating Triggers using the Slack CLI
+### Creating triggers using the Slack CLI
 
-To create a Trigger using the Slack CLI, create a file that contains your Trigger TypeScript format. Run the `trigger create` command with a `--trigger-def` flag pointing to your desired trigger file.
+To create a trigger using the Slack CLI, create a file that contains your trigger TypeScript format. Run the `trigger create` command with a `--trigger-def` flag pointing to your desired trigger file.
 
-```
+```zsh
 slack trigger create --trigger-def "path/to/trigger.ts"
 ```
 
 Example `trigger` objects in valid typescript and JSON formats can be viewed below. With a Generic Input these `trigger` objects will have access to typeahead for valid input parameters.
 
 #### With Generic Input
+
 ```ts
 import { Trigger } from "deno-slack-api/types.ts";
 import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
 
 const trigger: Trigger<typeof TriggersWorkflow.definition> = {
-  type: "shortcut", // the type of Trigger
-  name: "Request Time off", // the name of the Trigger
+  type: "shortcut", // the type of trigger
+  name: "Request Time off", // the name of the trigger
   description: "Starts the workflow to request time off", //Trigger description
-  workflow: "#/workflows/reverse_workflow", //the workflow your Trigger activates
+  workflow: "#/workflows/reverse_workflow", //the workflow your trigger activates
   inputs: { //Trigger inputs
     interactivity: {
       value: "{{data.interactivity}}",
@@ -61,14 +63,15 @@ export default trigger;
 ```
 
 #### Without Generic Input
+
 ```ts
 import { Trigger } from "deno-slack-api/types.ts";
 
 const trigger: Trigger = {
-  type: "shortcut", // the type of Trigger
-  name: "Request Time off", // the name of the Trigger
+  type: "shortcut", // the type of trigger
+  name: "Request Time off", // the name of the trigger
   description: "Starts the workflow to request time off", //Trigger description
-  workflow: "#/workflows/reverse_workflow", //the workflow your Trigger activates
+  workflow: "#/workflows/reverse_workflow", //the workflow your trigger activates
   inputs: { //Trigger inputs
     interactivity: {
       value: "{{data.interactivity}}",
@@ -79,12 +82,13 @@ const trigger: Trigger = {
 export default trigger;
 ```
 
-### Creating Triggers at runtime from your application
+### Creating triggers at runtime from your application
 
-Creating Triggers at runtime from within your application utilizes the `SlackAPI` client to make an API call to the Slack API.
-Creation uses the `client.workflows.triggers.create` method which takes in a Trigger object as input. 
+Creating triggers at runtime from within your application utilizes the `SlackAPI` client to make an API call to the Slack API.
+Creation uses the `client.workflows.triggers.create` method which takes in a trigger object as input.
 
 #### With Generic Input
+
 ```ts
   import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
 
@@ -120,23 +124,25 @@ Creation uses the `client.workflows.triggers.create` method which takes in a Tri
     },
   });
 ```
-## Updating Triggers
 
-Similar to creating, updating Triggers can be done through the CLI, or at runtime using the `client.workflows.triggers.update` method. Updating a Trigger takes the same Trigger object as creating one, with the addition of a `trigger_id` parameter to identify the Trigger being updated. More details on updating Triggers can be found in the [API documentation](https://api.dev.slack.com/future/triggers#update).
+## Updating triggers
 
-### Updating Triggers in the CLI
+Similar to creating, updating triggers can be done through the CLI, or at runtime using the `client.workflows.triggers.update` method. Updating a trigger takes the same trigger object as creating one, with the addition of a `trigger_id` parameter to identify the trigger being updated. More details on updating triggers can be found in the [API documentation](https://api.dev.slack.com/future/triggers#update).
 
-To update a Trigger using the Slack CLI, make the desired update to your existing [Trigger File](#creating-triggers-using-the-slack-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
+### Updating triggers in the CLI
 
-```
+To update a trigger using the Slack CLI, make the desired update to your existing [trigger File](#creating-triggers-using-the-slack-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
+
+```zsh
 slack trigger update --trigger-id Ft123ABC --trigger-def "path/to/trigger.ts"
 ```
 
-### Updating Triggers at runtime from your application
+### Updating triggers at runtime from your application
 
-Updating uses the `client.workflows.triggers.update` method which takes in the same Trigger object as the create call as input, with the addition of a `trigger_id` parameter. 
+Updating uses the `client.workflows.triggers.update` method which takes in the same trigger object as the create call as input, with the addition of a `trigger_id` parameter.
 
 #### With Generic Input
+
 ```ts
   import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
   const client = SlackAPI(token);
@@ -156,6 +162,7 @@ Updating uses the `client.workflows.triggers.update` method which takes in the s
 ```
 
 #### Without Generic Input
+
 ```ts
   import { TriggersWorkflow } from "../manifest.ts"; //The workflow you intend to use to define your trigger 
   const client = SlackAPI(token);
@@ -173,13 +180,14 @@ Updating uses the `client.workflows.triggers.update` method which takes in the s
     },
   });
 ```
-## Deleting Triggers 
 
-Triggers can be deleted by passing the Trigger ID. See the [API documentation](https://api.dev.slack.com/future/triggers#delete) for more details.
+## Deleting triggers
 
-### Delete a Trigger at runtime
+Triggers can be deleted by passing the trigger ID. See the [API documentation](https://api.dev.slack.com/future/triggers#delete) for more details.
 
-You can delete a Trigger at runtime by passing the desired `trigger_id` into `client.workflows.triggers.delete`.
+### Delete a trigger at runtime
+
+You can delete a trigger at runtime by passing the desired `trigger_id` into `client.workflows.triggers.delete`.
 
 ```ts
 client.workflows.triggers.delete({
@@ -187,13 +195,13 @@ client.workflows.triggers.delete({
 });
 ```
 
-## Listing Triggers
+## Listing triggers
 
-Keeping track of active Triggers can be done using the `List` command, which will return a list of active Triggers in your workspace. This can be done either through the CLI or at runtime.
+Keeping track of active triggers can be done using the `List` command, which will return a list of active triggers in your workspace. This can be done either through the CLI or at runtime.
 
-### Listing Triggers at runtime
+### Listing triggers at runtime
 
-Triggers can be listed at runtime using the `client.workflows.triggers.list` method. Using the client method will return an array of Trigger objects. The `list` method can be run with no input, however it also takes a variety of optional arguments to filter results. The optional arguments are as follows:
+Triggers can be listed at runtime using the `client.workflows.triggers.list` method. Using the client method will return an array of trigger objects. The `list` method can be run with no input, however it also takes a variety of optional arguments to filter results. The optional arguments are as follows:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
@@ -206,6 +214,7 @@ Triggers can be listed at runtime using the `client.workflows.triggers.list` met
 ### Usage Examples
 
 #### Filter list by a single app_id
+
 ```ts
   const client = SlackAPI(token);
 
@@ -215,6 +224,7 @@ Triggers can be listed at runtime using the `client.workflows.triggers.list` met
 ```
 
 #### Filter list by multiple app_ids
+
 ```ts
   const client = SlackAPI(token);
 
@@ -224,6 +234,7 @@ Triggers can be listed at runtime using the `client.workflows.triggers.list` met
 ```
 
 #### Filter list by single app_id and collaborator/owner/published status
+
 ```ts
   const client = SlackAPI(token);
 
@@ -235,8 +246,10 @@ Triggers can be listed at runtime using the `client.workflows.triggers.list` met
   });
 ```
 
-## Managing Trigger Access
+## Managing trigger Access
 
-A newly created Run on Slack Trigger will only be accessible to others inside a workspace once its creator has granted access.
+A newly created Run on Slack trigger will only be accessible to others inside a workspace once its creator has granted access.
 
-Use the `access` command to manage who can have access to run your Triggers. Details on granting and revoking Trigger access can be found in the [API documentation](https://api.dev.slack.com/future/triggers#manage-access)
+Use the `access` command to manage who can have access to run your triggers.
+Details on granting and revoking trigger access can be found in the [API
+documentation](https://api.dev.slack.com/future/triggers#manage-access)

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -2,12 +2,12 @@
 
 A trigger is an entry point for the execution of a [workflow](https://api.slack.com/future/workflows). triggers define the circumstances under which a workflow will be initiated and contain contextual information that can be
 passed along from the trigger to a workflow. Triggers come in different shapes and sizes, and there are four primary trigger types which can be used to activate a workflow.
-These four types are [Event](./event-triggers.md), [Shortcut](./shortcut-triggers.md), [Scheduled](./scheduled-trigger.md), and [Webhook](./webhook-triggers.md). Because triggers are the entry point of a workflow, a workflow needs to be defined before a trigger can be written for it. API information regarding triggers can be found at [here](https://api.slack.com/future/triggers)
+These four types are [event](./event-triggers.md), [shortcut](./shortcut-triggers.md), [scheduled](./scheduled-trigger.md), and [webhook](./webhook-triggers.md). Because triggers are the entry point of a workflow, a workflow needs to be defined before a trigger can be written for it. API information regarding triggers can be found at [here](https://api.slack.com/future/triggers)
 
 ### Trigger types
 
-There are currently 4 supported trigger types, [Shortcut](shortcut-trigger.md), [Webhook](webhook-trigger.md),
-[Event](event-trigger.md), and [Scheduled](scheduled-trigger.md). Each trigger type has it's own configuration object, however all triggers have parameters that are common to all trigger types, these common parameters are as follows:
+There are currently 4 supported trigger types, [shortcut](shortcut-trigger.md), [webhook](webhook-trigger.md),
+[event](event-trigger.md), and [scheduled](scheduled-trigger.md). Each trigger type has it's own configuration object, however all triggers have parameters that are common to all trigger types, these common parameters are as follows:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -246,7 +246,7 @@ Triggers can be listed at runtime using the `client.workflows.triggers.list` met
   });
 ```
 
-## Managing trigger Access
+## Managing trigger access
 
 A newly created Run on Slack trigger will only be accessible to others inside a workspace once its creator has granted access.
 

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -131,7 +131,7 @@ Similar to creating, updating triggers can be done through the CLI, or at runtim
 
 ### Updating triggers in the CLI
 
-To update a trigger using the Slack CLI, make the desired update to your existing [trigger File](#creating-triggers-using-the-slack-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
+To update a trigger using the Slack CLI, make the desired update to your existing [trigger file](#creating-triggers-using-the-slack-cli). When this is done, run the `slack trigger update` command from the CLI with a `--trigger-id` flag to identify the trigger to be updated.
 
 ```zsh
 slack trigger update --trigger-id Ft123ABC --trigger-def "path/to/trigger.ts"

--- a/docs/triggers/trigger-basics.md
+++ b/docs/triggers/trigger-basics.md
@@ -1,8 +1,8 @@
 ## What is a trigger?
 
-A trigger is an entry point for the execution of a [Workflow](https://api.slack.com/future/workflows). triggers define the circumstances under which a workflow will be initiated and contain contextual information that can be
-passed along from the trigger to a Workflow. Triggers come in different shapes and sizes, and there are four primary trigger types which can be used to activate a Workflow.
-These four types are [Event](./event-triggers.md), [Shortcut](./shortcut-triggers.md), [Scheduled](./scheduled-trigger.md), and [Webhook](./webhook-triggers.md). Because triggers are the entry point of a workflow, a Workflow needs to be defined before a trigger can be written for it. API information regarding triggers can be found at [here](https://api.slack.com/future/triggers)
+A trigger is an entry point for the execution of a [workflow](https://api.slack.com/future/workflows). triggers define the circumstances under which a workflow will be initiated and contain contextual information that can be
+passed along from the trigger to a workflow. Triggers come in different shapes and sizes, and there are four primary trigger types which can be used to activate a workflow.
+These four types are [Event](./event-triggers.md), [Shortcut](./shortcut-triggers.md), [Scheduled](./scheduled-trigger.md), and [Webhook](./webhook-triggers.md). Because triggers are the entry point of a workflow, a workflow needs to be defined before a trigger can be written for it. API information regarding triggers can be found at [here](https://api.slack.com/future/triggers)
 
 ### Trigger types
 
@@ -14,8 +14,8 @@ There are currently 4 supported trigger types, [Shortcut](shortcut-trigger.md), 
 | `type`            | Yes           | The type of trigger (one of `shortcut`, `event`, `scheduled`, or `webhook`)|
 | `name`            | Yes           | The name of the trigger                                              |
 | `description`     | No            | A description of the purpose of the trigger                          |
-| `workflow`        | Yes           | Which Workflow the trigger connects to                               |
-| `inputs`          | No            | What inputs (defined in the manifest) are passed to the Workflow      |
+| `workflow`        | Yes           | Which workflow the trigger connects to                               |
+| `inputs`          | No            | What inputs (defined in the manifest) are passed to the workflow      |
 
 The unique configuration objects for each trigger type can be found in their respective documents.
 

--- a/docs/triggers/trigger-filters.md
+++ b/docs/triggers/trigger-filters.md
@@ -1,6 +1,6 @@
-## Trigger Filters
+## Trigger filters
 
-A Trigger filter is an object that can be added to a Trigger on creation that will define the condition in which a Trigger should execute its associated workflow. A Trigger filter contains two parameters:
+A trigger filter is an object that can be added to a trigger on creation that will define the condition in which a trigger should execute its associated workflow. A trigger filter contains two parameters:
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
@@ -16,18 +16,19 @@ The root parameter can contain a combination of `Boolean logic` and `Conditional
 | `operator`         | Yes           | The logical operator to run against your filter inputs (AND, OR, NOT) as a string value  |
 | `inputs`            | Yes          | The filter inputs that contain filter statement definitions              |
 
-### `Conditional Expressions` 
+### `Conditional Expressions`
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|
 | `statement`         | Yes         | Comparison of values (uses one of the following operators: ">", "<", "==", "!= )|
 
-## Usage Examples
+## Usage examples
 
 Trigger filters can be composed of a single statement, or combine multiple statements using different logical comparators. Follow along to see different examples that build upon each other.
 
-### Single Statement
-A Trigger filter can use a single statement, which will execute when the statement is true.
+### Single statement
+
+A trigger filter can use a single statement, which will execute when the statement is true.
 
 ```ts
 {
@@ -38,9 +39,11 @@ A Trigger filter can use a single statement, which will execute when the stateme
 }
 ```
 
-### Logical Operators
-A Trigger filter can also use simple logical operators to compare multiple statements and evaluate their outcome.
-```ts 
+### Logical operators
+
+A trigger filter can also use simple logical operators to compare multiple statements and evaluate their outcome.
+
+```ts
 {
     version: 1,
     root: {
@@ -54,7 +57,7 @@ A Trigger filter can also use simple logical operators to compare multiple state
   }
 ```
 
-```ts 
+```ts
 {
     version: 1,
     root: {
@@ -68,8 +71,10 @@ A Trigger filter can also use simple logical operators to compare multiple state
   }
 ```
 
-### Nested Logical Operators
-A Trigger filter can make use of nested logical operators and statements for more complicated conditional evaluations.
+### Nested logical operators
+
+A trigger filter can make use of nested logical operators and statements for more complicated conditional evaluations.
+
 ```ts
 {
     version: 1,
@@ -95,4 +100,3 @@ A Trigger filter can make use of nested logical operators and statements for mor
     },
   }
 ```
-

--- a/docs/triggers/trigger-filters.md
+++ b/docs/triggers/trigger-filters.md
@@ -16,7 +16,7 @@ The root parameter can contain a combination of `Boolean logic` and `Conditional
 | `operator`         | Yes           | The logical operator to run against your filter inputs (AND, OR, NOT) as a string value  |
 | `inputs`            | Yes          | The filter inputs that contain filter statement definitions              |
 
-### `Conditional Expressions`
+### `Conditional expressions`
 
 | Parameter name  | Required?     | Description                                                          |
 | ----------------|:-------------:| ---------------------------------------------------------------------|

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -11,7 +11,7 @@ When a workflow is created in this manner, it contains a `workflow.definition` o
 
 When dealing with triggers at runtime, a workflow definition input can optionally be passed to the trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
 
-### Using trigger Generics at runtime Example
+### Using trigger generics at runtime Example
 
 ```ts
 import { TriggersWorkflow } from "../manifest.ts";

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -1,17 +1,17 @@
-# Trigger Generics
+# Trigger generics
 
-When creating or updating a trigger, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs. 
+When creating or updating a trigger, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs.
 
-## Defining A Workflow
+## Defining a workflow
 
 Recall that in the [SDK](https://github.com/slackapi/deno-slack-sdk/blob/main/docs/workflows.md#workflows), a `workflow` can be defined using the `DefineWorkflow` method.
 When a workflow is created in this manner, it contains a `workflow.definition` object. By passing this definition into the `create` or `update` method, the trigger will have access to information related to the workflow's definition.
 
-## Workflow Definition Input with Runtime Triggers
+## Workflow definition input with runtime triggers
 
-When dealing with Triggers at runtime, a Workflow definition input can optionally be passed to the Trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
+When dealing with triggers at runtime, a Workflow definition input can optionally be passed to the trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
 
-### Using Trigger Generics at runtime Example 
+### Using trigger Generics at runtime Example
 
 ```ts
 import { TriggersWorkflow } from "../manifest.ts";
@@ -43,11 +43,12 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
     },
 }
 ```
-## Workflow Definition Input with CLI Triggers
 
-A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a Trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `Trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.
+## Workflow definition input with CLI triggers
 
-### Using Trigger Generics with CLI Example
+A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.
+
+### Using trigger generics with CLI Example
 
 ```ts
 import { Trigger } from "deno-slack-api/types.ts";

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -1,6 +1,6 @@
 # Trigger generics
 
-When creating or updating a trigger, a Workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs.
+When creating or updating a trigger, a workflow definition can be passed into the `client.workflows.triggers.create` and `client.workflows.triggers.update` methods as a generic which will allow for typeahead/autocomplete of the input parameters based on the definition's inputs.
 
 ## Defining a workflow
 
@@ -9,7 +9,7 @@ When a workflow is created in this manner, it contains a `workflow.definition` o
 
 ## Workflow definition input with runtime triggers
 
-When dealing with triggers at runtime, a Workflow definition input can optionally be passed to the trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
+When dealing with triggers at runtime, a workflow definition input can optionally be passed to the trigger's `create` or `update` API call as a generic. When a generic is passed, the object argument being defined will have access to typeahead on the `inputs` and `workflow` properties.
 
 ### Using trigger Generics at runtime Example
 
@@ -30,7 +30,7 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
     name: "Request Time off",
     description: "Starts the workflow to request time off",
     workflow: "#/workflows/reverse_workflow",
-    inputs: { //inputs can now be autofilled from the Workflow Definition
+    inputs: { //inputs can now be autofilled from the workflow Definition
       a_string: {
         value: "TEST",
       },
@@ -46,7 +46,7 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
 
 ## Workflow definition input with CLI triggers
 
-A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a trigger through the CLI. When passing the definition input in this manner, the `Workflow` definition is passed as a generic to the `trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.
+A `workflow` definition input can also be passed to the `trigger` file that is used to create or update a trigger through the CLI. When passing the definition input in this manner, the `workflow` definition is passed as a generic to the `trigger` object instead of the `create` or `update` method. With an Input Generic, the `trigger` object being defined will have access to typeahead on the expected parameters to be passed in.
 
 ### Using trigger generics with CLI Example
 
@@ -59,7 +59,7 @@ const trigger: Trigger<typeof TriggersWorkflow.definition> = { //Workflow defini
   name: "Get Triggers List",
   description: "Starts the workflow to request time off",
   workflow: "#/workflows/list_trigger_workflow",
-  inputs: {    //The inputs parameter will now have typeahead based on the Workflow definition being passed in.
+  inputs: {    //The inputs parameter will now have typeahead based on the workflow definition being passed in.
     a_input: {
       value: "test_value"
     }

--- a/docs/triggers/trigger-generic-inputs.md
+++ b/docs/triggers/trigger-generic-inputs.md
@@ -30,7 +30,7 @@ import { SlackAPI } from "deno-slack-api/mod.ts";
     name: "Request Time off",
     description: "Starts the workflow to request time off",
     workflow: "#/workflows/reverse_workflow",
-    inputs: { //inputs can now be autofilled from the workflow Definition
+    inputs: { //inputs can now be autofilled from the workflow definition
       a_string: {
         value: "TEST",
       },

--- a/docs/triggers/webhook-triggers.md
+++ b/docs/triggers/webhook-triggers.md
@@ -1,6 +1,6 @@
 ## Webhook triggers
 
-A Webhook trigger is a trigger that activates on a webhook activation in the Slack client. A webhook trigger
+A webhook trigger is a trigger that activates on a webhook activation in the Slack client. A webhook trigger
 includes the common trigger parameters along with a webhook parameter:
 
 | Parameter name| Required?     | Description                                                          |
@@ -20,7 +20,7 @@ A webhook trigger can contain an optional `webhook` configuration object which s
 
 ### Context data availability
 
-Like other trigger types, Webhook triggers have access to context data which can be used to fill the `inputs` parameter. Unlike other triggers, the context data available
+Like other trigger types, webhook triggers have access to context data which can be used to fill the `inputs` parameter. Unlike other triggers, the context data available
 to a webhook trigger is not predetermined, and will depend on the information sent along with the webhook to activate the trigger. Whatever data contained in the HTTP body of the webhook request
 is what will be available in `{{data}}`. So an HTTP request made with a body of `{"test": true}` would yield a context data object that could be referenced like `{{data.test}}`.
 

--- a/docs/triggers/webhook-triggers.md
+++ b/docs/triggers/webhook-triggers.md
@@ -1,16 +1,16 @@
-## Webhook Triggers
+## Webhook triggers
 
-A Webhook Trigger is a Trigger that activates on a webhook activation in the Slack client. A Webhook Trigger
-includes the common Trigger parameters along with a webhook parameter: 
+A Webhook trigger is a trigger that activates on a webhook activation in the Slack client. A webhook trigger
+includes the common trigger parameters along with a webhook parameter:
 
 | Parameter name| Required?     | Description                                                          |
 | --------------|:-------------:| ---------------------------------------------------------------------|
-| `inputs`        | Yes           | What inputs (defined in the manifest) are passed to the Trigger      |
+| `inputs`        | Yes           | What inputs (defined in the manifest) are passed to the trigger      |
 | `webook`        | No            | Contains a [filter](trigger-filters.md)             |
 
-### Webhook Configuration
+### Webhook configuration
 
-A Webhook Trigger can contain an optional `webhook` configuration object which specifies a `filter`:
+A webhook trigger can contain an optional `webhook` configuration object which specifies a `filter`:
 
 ```ts
   webhook?: {
@@ -18,14 +18,16 @@ A Webhook Trigger can contain an optional `webhook` configuration object which s
   };
 ```
 
-### Context Data Availability
-Like other Trigger types, Webhook Triggers have access to context data which can be used to fill the `inputs` parameter. Unlike other Triggers, the context data available
-to a webhook Trigger is not predetermined, and will depend on the information sent along with the webhook to activate the Trigger. Whatever data contained in the HTTP body of the webhook request 
+### Context data availability
+
+Like other trigger types, Webhook triggers have access to context data which can be used to fill the `inputs` parameter. Unlike other triggers, the context data available
+to a webhook trigger is not predetermined, and will depend on the information sent along with the webhook to activate the trigger. Whatever data contained in the HTTP body of the webhook request
 is what will be available in `{{data}}`. So an HTTP request made with a body of `{"test": true}` would yield a context data object that could be referenced like `{{data.test}}`.
 
 ## Usage
 
-### Webhook Trigger Without Filter
+### Webhook trigger without filter
+
 ```ts
 const trigger: Trigger = {
   type: "webhook",
@@ -39,7 +41,8 @@ const trigger: Trigger = {
   },
 };
 ```
-### Webhook Trigger With Filter
+
+### Webhook trigger with filter
 
 ```ts
 const trigger: Trigger = {
@@ -64,6 +67,7 @@ const trigger: Trigger = {
 ```
 
 ## Example Response
+
 ```ts
 {
   ok: true,
@@ -97,12 +101,13 @@ const trigger: Trigger = {
 }
 ```
 
-## Invoking the Trigger 
+## Invoking the trigger
 
-Send a POST request to invoke the Trigger. Within that POST request you can send values for specific inputs.
+Send a POST request to invoke the trigger. Within that POST request you can send values for specific inputs.
 
 Example POST request
-```
+
+```bash
 curl \ 
 -X POST "https://hooks.slack.com/triggers/T123ABC456/.../..." \
 --header "Content-Type: application/json" \
@@ -111,7 +116,7 @@ curl \
 
 If successful, you'll get the following response:
 
-```
+```json
 {
   "ok":true
 }

--- a/scripts/src/public-api-methods.ts
+++ b/scripts/src/public-api-methods.ts
@@ -223,7 +223,6 @@ export const getPublicAPIMethods = () => {
     "workflows.updateStep",
   ];
 
-  // upcoming platform 2.0 methods we want available but aren't listed quite yet
   const platform2Methods = [
     "functions.completeError",
     "functions.completeSuccess",

--- a/scripts/src/public-api-methods.ts
+++ b/scripts/src/public-api-methods.ts
@@ -223,6 +223,7 @@ export const getPublicAPIMethods = () => {
     "workflows.updateStep",
   ];
 
+  // next gen platform methods we want available but aren't listed quite yet
   const nextGenPlatformMethods = [
     "functions.completeError",
     "functions.completeSuccess",

--- a/scripts/src/public-api-methods.ts
+++ b/scripts/src/public-api-methods.ts
@@ -223,14 +223,14 @@ export const getPublicAPIMethods = () => {
     "workflows.updateStep",
   ];
 
-  const platform2Methods = [
+  const nextGenPlatformMethods = [
     "functions.completeError",
     "functions.completeSuccess",
   ];
 
   const methodsSet = new Set([
     ...publicAPIMethods,
-    ...platform2Methods,
+    ...nextGenPlatformMethods,
   ]);
 
   methodsWithCustomTypes.forEach((customMethod) => {

--- a/src/typed-method-types/workflows/triggers/event.ts
+++ b/src/typed-method-types/workflows/triggers/event.ts
@@ -102,7 +102,7 @@ type BaseWorkspaceEvent = BaseEvent & {
 };
 
 type BaseEvent = {
-  /** @description Defines the condition in which this event trigger should execute the Workflow */
+  /** @description Defines the condition in which this event trigger should execute the workflow */
   filter?: FilterType;
   // deno-lint-ignore no-explicit-any
   [otherOptions: string]: any;

--- a/src/typed-method-types/workflows/triggers/scheduled.ts
+++ b/src/typed-method-types/workflows/triggers/scheduled.ts
@@ -150,7 +150,7 @@ export type ScheduledTriggerResponseObject<
   & BaseTriggerResponse<WorkflowDefinition>
   & {
     /**
-     * @description A schedule object returned by Scheduled triggers
+     * @description A schedule object returned by scheduled triggers
      */
     // deno-lint-ignore no-explicit-any
     schedule?: Record<string, any>;

--- a/src/typed-method-types/workflows/triggers/tests/event_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/event_test.ts
@@ -5,7 +5,7 @@ import { SlackAPI } from "../../../../mod.ts";
 import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 import { event_response } from "./fixtures/sample_responses.ts";
 
-Deno.test("Event Triggers can set the type using the string", () => {
+Deno.test("Event triggers can set the type using the string", () => {
   // deno-lint-ignore no-explicit-any
   const event: EventTrigger<any> = {
     type: "event",
@@ -20,7 +20,7 @@ Deno.test("Event Triggers can set the type using the string", () => {
   assertEquals(event.type, TriggerTypes.Event);
 });
 
-Deno.test("Event Triggers can set the type using the TriggerTypes object", () => {
+Deno.test("Event triggers can set the type using the TriggerTypes object", () => {
   // deno-lint-ignore no-explicit-any
   const event: EventTrigger<any> = {
     type: TriggerTypes.Event,

--- a/src/typed-method-types/workflows/triggers/tests/scheduled_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/scheduled_test.ts
@@ -4,7 +4,7 @@ import { TriggerTypes } from "../mod.ts";
 import { SlackAPI } from "../../../../mod.ts";
 import { scheduled_response } from "./fixtures/sample_responses.ts";
 
-Deno.test("Scheduled Triggers can be set with a string", () => {
+Deno.test("Scheduled triggers can be set with a string", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -18,7 +18,7 @@ Deno.test("Scheduled Triggers can be set with a string", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set with TriggerTypes object", () => {
+Deno.test("Scheduled triggers can be set with TriggerTypes object", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -32,7 +32,7 @@ Deno.test("Scheduled Triggers can be set with TriggerTypes object", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set with just the start_time property", () => {
+Deno.test("Scheduled triggers can be set with just the start_time property", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -46,7 +46,7 @@ Deno.test("Scheduled Triggers can be set with just the start_time property", () 
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set just once", () => {
+Deno.test("Scheduled triggers can be set just once", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -61,7 +61,7 @@ Deno.test("Scheduled Triggers can be set just once", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set just once with explicit once frequency type", () => {
+Deno.test("Scheduled triggers can be set just once with explicit once frequency type", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -77,7 +77,7 @@ Deno.test("Scheduled Triggers can be set just once with explicit once frequency 
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be recurring hourly", () => {
+Deno.test("Scheduled triggers can be set to be recurring hourly", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -94,7 +94,7 @@ Deno.test("Scheduled Triggers can be set to be recurring hourly", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be recurring", () => {
+Deno.test("Scheduled triggers can be set to be recurring", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -111,7 +111,7 @@ Deno.test("Scheduled Triggers can be set to be recurring", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be reoccur daily", () => {
+Deno.test("Scheduled triggers can be set to be reoccur daily", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -129,7 +129,7 @@ Deno.test("Scheduled Triggers can be set to be reoccur daily", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be reoccur weekly", () => {
+Deno.test("Scheduled triggers can be set to be reoccur weekly", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -148,7 +148,7 @@ Deno.test("Scheduled Triggers can be set to be reoccur weekly", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be reoccur monthly", () => {
+Deno.test("Scheduled triggers can be set to be reoccur monthly", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",
@@ -168,7 +168,7 @@ Deno.test("Scheduled Triggers can be set to be reoccur monthly", () => {
   assertEquals(schedule.type, TriggerTypes.Scheduled);
 });
 
-Deno.test("Scheduled Triggers can be set to be reoccur yearly", () => {
+Deno.test("Scheduled triggers can be set to be reoccur yearly", () => {
   // deno-lint-ignore no-explicit-any
   const schedule: ScheduledTrigger<any> = {
     name: "Sample",

--- a/src/typed-method-types/workflows/triggers/tests/shortcut_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/shortcut_test.ts
@@ -9,7 +9,7 @@ import type {
   RequiredInputWorkflow,
 } from "./fixtures/workflows.ts";
 
-Deno.test("Shortcut Triggers can set the type using the string", () => {
+Deno.test("Shortcut triggers can set the type using the string", () => {
   const shortcut: ShortcutTrigger<ExampleWorkflow> = {
     type: "shortcut",
     name: "test",
@@ -18,7 +18,7 @@ Deno.test("Shortcut Triggers can set the type using the string", () => {
   assertEquals(shortcut.type, TriggerTypes.Shortcut);
 });
 
-Deno.test("Shortcut Triggers can set the type using the TriggerTypes object", () => {
+Deno.test("Shortcut triggers can set the type using the TriggerTypes object", () => {
   const shortcut: ShortcutTrigger<RequiredInputWorkflow> = {
     type: TriggerTypes.Shortcut,
     name: "test",

--- a/src/typed-method-types/workflows/triggers/tests/webhook_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/webhook_test.ts
@@ -4,7 +4,7 @@ import { TriggerTypes } from "../mod.ts";
 import { SlackAPI } from "../../../../mod.ts";
 import { webhook_response } from "./fixtures/sample_responses.ts";
 
-Deno.test("Webhook Triggers can set the type using the string", () => {
+Deno.test("Webhook triggers can set the type using the string", () => {
   // deno-lint-ignore no-explicit-any
   const webhook: WebhookTrigger<any> = {
     type: "webhook",
@@ -15,7 +15,7 @@ Deno.test("Webhook Triggers can set the type using the string", () => {
   assertEquals(webhook.type, TriggerTypes.Webhook);
 });
 
-Deno.test("Webhook Triggers can set the type using the TriggerTypes object", () => {
+Deno.test("Webhook triggers can set the type using the TriggerTypes object", () => {
   // deno-lint-ignore no-explicit-any
   const webhook: WebhookTrigger<any> = {
     type: TriggerTypes.Webhook,
@@ -26,7 +26,7 @@ Deno.test("Webhook Triggers can set the type using the TriggerTypes object", () 
   assertEquals(webhook.type, TriggerTypes.Webhook);
 });
 
-Deno.test("Webhook Triggers support an optional filter object", () => {
+Deno.test("Webhook triggers support an optional filter object", () => {
   // deno-lint-ignore no-explicit-any
   const webhook: WebhookTrigger<any> = {
     type: TriggerTypes.Webhook,

--- a/src/typed-method-types/workflows/triggers/webhook.ts
+++ b/src/typed-method-types/workflows/triggers/webhook.ts
@@ -13,7 +13,7 @@ export type WebhookTrigger<WorkflowDefinition extends WorkflowSchema> =
   & {
     type: typeof TriggerTypes.Webhook;
     webhook?: {
-      /** @description Defines the condition in which this webhook trigger should execute the Workflow */
+      /** @description Defines the condition in which this webhook trigger should execute the workflow */
       filter?: FilterType;
     };
   };


### PR DESCRIPTION
###  Summary

This PR aims to update the project to follow the new Slack Term Glossary, this mainly affect documentation and comments, variable names were left unchanged to avoid breaking changes.

__NOTE__ I think some of this documentation might be duplicated in https://api.slack.com/future/triggers, lmk if we want to remove it from here or make a ticket to remove it

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
