### PR TITLE
Shared channel trigger events have optional `channel_ids` 

### DIFF
--- a/src/typed-method-types/workflows/triggers/event.ts
+++ b/src/typed-method-types/workflows/triggers/event.ts
@@ -36,16 +36,6 @@ type ChannelTypes = ObjectValueUnion<
   >
 >;
 
-type SharedChannelTypes = ObjectValueUnion<
-  Pick<
-    typeof TriggerEventTypes,
-    | "SharedChannelInviteAccepted"
-    | "SharedChannelInviteApproved"
-    | "SharedChannelInviteDeclined"
-    | "SharedChannelInviteReceived"
-  >
->;
-
 type WorkspaceTypes = ObjectValueUnion<
   Pick<
     typeof TriggerEventTypes,
@@ -56,6 +46,10 @@ type WorkspaceTypes = ObjectValueUnion<
     | "ChannelUnarchived"
     | "DndUpdated"
     | "EmojiChanged"
+    | "SharedChannelInviteAccepted"
+    | "SharedChannelInviteApproved"
+    | "SharedChannelInviteDeclined"
+    | "SharedChannelInviteReceived"
     | "UserJoinedTeam"
   >
 >;
@@ -63,8 +57,7 @@ type WorkspaceTypes = ObjectValueUnion<
 export type ChannelEvents =
   | ChannelEvent
   | MetadataChannelEvent
-  | MessagePostedEvent
-  | SharedChannelEvent;
+  | MessagePostedEvent;
 
 type BaseChannelEvent = BaseEvent & {
   /** @description The channel id's that this event listens on */
@@ -92,14 +85,6 @@ type MessagePostedEvent =
   & {
     /** @description The type of event */
     event_type: MessagePostedEventType;
-  };
-
-type SharedChannelEvent =
-  & Omit<BaseChannelEvent, "channel_ids">
-  & Partial<Pick<BaseChannelEvent, "channel_ids">>
-  & {
-    /** @description The type of event */
-    event_type: SharedChannelTypes;
   };
 
 type WorkspaceEvents =

--- a/src/typed-method-types/workflows/triggers/event.ts
+++ b/src/typed-method-types/workflows/triggers/event.ts
@@ -27,6 +27,7 @@ type ChannelTypes = ObjectValueUnion<
     | "AppMentioned"
     | "ChannelShared"
     | "ChannelUnshared"
+    | "MessageMetadataPosted"
     | "PinAdded"
     | "PinRemoved"
     | "ReactionAdded"
@@ -54,33 +55,32 @@ type WorkspaceTypes = ObjectValueUnion<
   >
 >;
 
-export type ChannelEvents =
-  | ChannelEvent
-  | MetadataChannelEvent
-  | MessagePostedEvent;
+type ChannelEvents =
+  & (ChannelEvent | MetadataChannelEvent | MessagePostedEvent)
+  & {
+    /** @description The channel id's that this event listens on */
+    channel_ids: PopulatedArray<string>;
+    // deno-lint-ignore no-explicit-any
+    [otherOptions: string]: any;
+  };
 
-type BaseChannelEvent = BaseEvent & {
-  /** @description The channel id's that this event listens on */
-  channel_ids: PopulatedArray<string>;
-};
-
-type ChannelEvent = BaseChannelEvent & {
+type ChannelEvent = BaseEvent & {
   /** @description The type of event */
-  event_type: ChannelTypes;
+  event_type: Exclude<ChannelTypes, MessageMetadataTypes>;
 };
 
 type MetadataChannelEvent =
-  & BaseChannelEvent
+  & BaseEvent
   & {
     /** @description The type of event */
-    event_type: MessageMetadataTypes;
+    event_type: Extract<ChannelTypes, MessageMetadataTypes>;
     /** @description User defined description for the metadata event type */
     metadata_event_type: string;
   };
 
 // The only event that currently requires a filter
 type MessagePostedEvent =
-  & BaseChannelEvent
+  & BaseEvent
   & Required<Pick<BaseEvent, "filter">>
   & {
     /** @description The type of event */
@@ -92,6 +92,8 @@ type WorkspaceEvents =
   & {
     /** @description The team id's that this event listens on */
     team_ids?: PopulatedArray<string>;
+    // deno-lint-ignore no-explicit-any
+    [otherOptions: string]: any;
   };
 
 type BaseWorkspaceEvent = BaseEvent & {

--- a/src/typed-method-types/workflows/triggers/tests/event_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/event_test.ts
@@ -34,6 +34,19 @@ Deno.test("Event triggers can set the type using the TriggerTypes object", () =>
   assertEquals(event.type, TriggerTypes.Event);
 });
 
+Deno.test("shared_channel_invite_* event triggers do not require channel_ids", () => {
+  const event: EventTrigger<ExampleWorkflow> = {
+    type: TriggerTypes.Event,
+    name: "test",
+    workflow: "#/workflows/example",
+    inputs: {},
+    event: {
+      event_type: "slack#/events/shared_channel_invite_accepted",
+    },
+  };
+  assertEquals(event.type, TriggerTypes.Event);
+});
+
 Deno.test("Mock call for event", async (t) => {
   mf.install(); // mock out calls to `fetch`
 

--- a/src/typed-method-types/workflows/triggers/tests/event_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/event_test.ts
@@ -1,13 +1,13 @@
-import { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
-import { EventTrigger } from "../event.ts";
+import { assertEquals } from "../../../../dev_deps.ts";
 import { TriggerTypes } from "../mod.ts";
 import { SlackAPI } from "../../../../mod.ts";
 import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 import { event_response } from "./fixtures/sample_responses.ts";
+import { ExampleWorkflow } from "./fixtures/workflows.ts";
+import { EventTrigger } from "../event.ts";
 
 Deno.test("Event triggers can set the type using the string", () => {
-  // deno-lint-ignore no-explicit-any
-  const event: EventTrigger<any> = {
+  const event: EventTrigger<ExampleWorkflow> = {
     type: "event",
     name: "test",
     workflow: "#/workflows/example",
@@ -21,8 +21,7 @@ Deno.test("Event triggers can set the type using the string", () => {
 });
 
 Deno.test("Event triggers can set the type using the TriggerTypes object", () => {
-  // deno-lint-ignore no-explicit-any
-  const event: EventTrigger<any> = {
+  const event: EventTrigger<ExampleWorkflow> = {
     type: TriggerTypes.Event,
     name: "test",
     workflow: "#/workflows/example",


### PR DESCRIPTION
###  Summary

This PR sets the `channel_ids` field of the `shared_channel_invite_*` event triggers as optional.

#### Before 
TS error would appear
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/25348381/233471213-ad6cc24b-3f96-451f-be87-aad960ed829c.gif)

#### After

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/25348381/233471082-dde8bdff-3b32-4c33-b471-dc271a795cf6.gif)
 
NOTE: Can't think of a good way to test this since there is no strong type inference

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
