### PR TITLE
Fast follow changes for the new trigger data enum

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,10 +2,7 @@ import { BaseSlackAPIClient } from "./base-client.ts";
 import { SlackAPIOptions } from "./types.ts";
 import { ProxifyAndTypeClient } from "./api-proxy.ts";
 
-export {
-  TriggerContextData,
-  TriggerTypes,
-} from "./typed-method-types/workflows/triggers/mod.ts";
+export { TriggerTypes } from "./typed-method-types/workflows/triggers/mod.ts";
 export { TriggerEventTypes } from "./typed-method-types/workflows/triggers/trigger-event-types.ts";
 
 export const SlackAPI = (token: string, options: SlackAPIOptions = {}) => {

--- a/src/typed-method-types/workflows/triggers/event-data/dnd_updated.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/dnd_updated.ts
@@ -1,4 +1,4 @@
-const DNDStatus = {
+const DndStatus = {
   /**
    * Whether Do Not Disturb is enabled or not.
    */
@@ -13,15 +13,15 @@ const DNDStatus = {
   next_dnd_start_ts: "{{data.dnd_status.next_dnd_start_ts}}",
 };
 
-Object.defineProperty(DNDStatus, "toJSON", {
+Object.defineProperty(DndStatus, "toJSON", {
   value: () => "{{data.dnd_status}}",
 });
 
-export const DNDUpdated = {
+export const DndUpdated = {
   /**
    * Do Not Disturb object containing all DND-related data.
    */
-  dnd_status: DNDStatus,
+  dnd_status: DndStatus,
   /**
    * The event type being invoked. At runtime will always be "slack#/events/dnd_updated".
    */

--- a/src/typed-method-types/workflows/triggers/event-data/mod.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/mod.ts
@@ -6,7 +6,7 @@ import { ChannelRenamed } from "./channel_renamed.ts";
 import { ChannelShared } from "./channel_shared.ts";
 import { ChannelUnarchived } from "./channel_unarchived.ts";
 import { ChannelUnshared } from "./channel_unshared.ts";
-import { DNDUpdated } from "./dnd_updated.ts";
+import { DndUpdated } from "./dnd_updated.ts";
 import { EmojiChanged } from "./emoji_changed.ts";
 import { MessageMetadataPosted } from "./message_metadata_posted.ts";
 import { MessagePosted } from "./message_posted.ts";
@@ -62,7 +62,7 @@ export const EventTriggerContextData = {
   /**
    * Do Not Disturb settings updated for a member.
    */
-  DNDUpdated,
+  DndUpdated,
   /**
    * An emoji was added, removed or renamed in the workspace.
    */

--- a/src/typed-method-types/workflows/triggers/shortcut-data.ts
+++ b/src/typed-method-types/workflows/triggers/shortcut-data.ts
@@ -51,7 +51,7 @@ export const ShortcutTriggerContextData = {
   /**
    * An object that contains context about the particular interactivity event that tripped the trigger. For consumption in functions that involve {@link https://api.slack.com/automation/block-events Block Kit} or {@link https://api.slack.com/automation/view-events Modal View} interactivity.
    */
-  interactivity: "{{data.interactivity}}",
+  interactivity: Interactivity,
   /**
    * Where the trigger was invoked. At runtime, the value will be one of the following strings, depending on the invocation source: `message` when invoked from a message, `bookmark` when invoked from a bookmark, or `button` when invoked from a {@link https://api.slack.com/automation/triggers/link#workflow_buttons Workflow Button}.
    */

--- a/src/typed-method-types/workflows/triggers/tests/context_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/context_test.ts
@@ -1,0 +1,103 @@
+import { assertEquals } from "../../../../dev_deps.ts";
+import { TriggerContextData } from "../mod.ts";
+
+Deno.test("TriggerContextData Objects allow property access or string references", async (t) => {
+  const { Shortcut, Event } = TriggerContextData;
+
+  await t.step("Shortcut Triggers", async (tt) => {
+    const { interactivity } = Shortcut;
+
+    await tt.step(
+      "support string references for objects when stringifying JSON",
+      () => {
+        assertEquals(
+          JSON.stringify(interactivity),
+          `"{{data.interactivity}}"`,
+        );
+        assertEquals(
+          JSON.stringify(interactivity.interactor),
+          `"{{data.interactivity.interactor}}"`,
+        );
+      },
+    );
+    await tt.step("support property references for objects", () => {
+      assertEquals(
+        JSON.stringify(interactivity.interactor.id),
+        `"{{data.interactivity.interactor.id}}"`,
+      );
+    });
+  });
+
+  await t.step("Event Triggers", async (tt) => {
+    const {
+      DndUpdated,
+      SharedChannelInviteAccepted,
+      SharedChannelInviteApproved,
+      SharedChannelInviteDeclined,
+      UserJoinedTeam,
+    } = Event;
+    await tt.step(
+      "support string references for objects when stringifying JSON",
+      () => {
+        assertEquals(
+          JSON.stringify(DndUpdated.dnd_status),
+          `"{{data.dnd_status}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteAccepted.accepting_user),
+          `"{{data.accepting_user}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteApproved.approving_user),
+          `"{{data.approving_user}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteDeclined.declining_user),
+          `"{{data.declining_user}}"`,
+        );
+        assertEquals(
+          JSON.stringify(UserJoinedTeam.user),
+          `"{{data.user}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteAccepted.invite),
+          `"{{data.invite}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteAccepted.invite.inviting_team),
+          `"{{data.invite.inviting_team}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteAccepted.invite.inviting_team.icon),
+          `"{{data.invite.inviting_team.icon}}"`,
+        );
+        assertEquals(
+          JSON.stringify(SharedChannelInviteAccepted.invite.inviting_user),
+          `"{{data.invite.inviting_user}}"`,
+        );
+      },
+    );
+    await tt.step("support property references for objects", () => {
+      assertEquals(
+        JSON.stringify(DndUpdated.dnd_status.dnd_enabled),
+        `"{{data.dnd_status.dnd_enabled}}"`,
+      );
+      assertEquals(
+        JSON.stringify(SharedChannelInviteApproved.approving_user.id),
+        `"{{data.approving_user.id}}"`,
+      );
+      assertEquals(
+        JSON.stringify(SharedChannelInviteDeclined.declining_user.name),
+        `"{{data.declining_user.name}}"`,
+      );
+      assertEquals(
+        JSON.stringify(UserJoinedTeam.user.real_name),
+        `"{{data.user.real_name}}"`,
+      );
+      assertEquals(
+        JSON.stringify(SharedChannelInviteAccepted.invite.inviting_team.domain),
+        `"{{data.invite.inviting_team.domain}}"`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
###  Summary

Fast follow changes for the new trigger data enum
- Remove `TriggerContextData` from top level export
  - We're planning to introduce `TriggerContext` in a follow-up PR, but we don't want to release `TriggerContextData` in the meantime
- Change from `DNDUpdated` to `DndUpdated` (same for `DndStatus`) to match whats in `trigger-event-types.ts` file
- Update `interactivity` to use the object instead of string reference
- Add tests

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
