### PR TITLE
Add TriggerContext object

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,7 +2,10 @@ import { BaseSlackAPIClient } from "./base-client.ts";
 import { SlackAPIOptions } from "./types.ts";
 import { ProxifyAndTypeClient } from "./api-proxy.ts";
 
-export { TriggerTypes } from "./typed-method-types/workflows/triggers/mod.ts";
+export {
+  TriggerContext,
+  TriggerTypes,
+} from "./typed-method-types/workflows/triggers/mod.ts";
 export { TriggerEventTypes } from "./typed-method-types/workflows/triggers/trigger-event-types.ts";
 
 export const SlackAPI = (token: string, options: SlackAPIOptions = {}) => {

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -52,7 +52,7 @@ export const TriggerTypes = {
 } as const;
 
 /**
- * Data available on different triggers for use in workflow inputs.
+ * Data available based on the type of trigger for use in workflow inputs.
  */
 export const TriggerContextData = {
   /**
@@ -64,9 +64,39 @@ export const TriggerContextData = {
    */
   Shortcut: ShortcutTriggerContextData,
   /**
-   * Data available from the variety of different eventr triggers for use in workflow inputs.
+   * Data available from the variety of different event triggers for use in workflow inputs.
    */
   Event: EventTriggerContextData,
+} as const;
+
+/**
+ * Data available on triggers for use in workflow inputs.
+ */
+export const TriggerContext = {
+  /**
+   * A unique identifier for the team or workspace where the trigger was invoked.
+   */
+  TeamId: "{{team_id}}",
+  /**
+   * A unique identifier for the enterprise where the trigger was invoked. Only available when trigger is invoked within an enterprise.
+   */
+  EnterpriseId: "{{enterprise_id}}",
+  /**
+   * A unique identifier for the event that occurred. Only available when trigger is invoked from an event.
+   */
+  EventId: "{{event_id}}",
+  /**
+   * A UNIX timestamp representing the time the event occurred.
+   */
+  EventTimestamp: "{{event_timestamp}}",
+  /**
+   * The type of trigger, this value will match the type value passed to the trigger.
+   */
+  Type: "{{type}}",
+  /**
+   * Data available based on the type of trigger for use in workflow inputs.
+   */
+  Data: TriggerContextData,
 } as const;
 
 // Set defaults for any direct uses of this type

--- a/src/typed-method-types/workflows/triggers/tests/context_test.ts
+++ b/src/typed-method-types/workflows/triggers/tests/context_test.ts
@@ -1,5 +1,13 @@
 import { assertEquals } from "../../../../dev_deps.ts";
-import { TriggerContextData } from "../mod.ts";
+import { TriggerContext, TriggerContextData } from "../mod.ts";
+
+Deno.test("TriggerContext surfaces appropriate shared context", () => {
+  assertEquals(TriggerContext.EnterpriseId, "{{enterprise_id}}");
+  assertEquals(TriggerContext.EventId, "{{event_id}}");
+  assertEquals(TriggerContext.EventTimestamp, "{{event_timestamp}}");
+  assertEquals(TriggerContext.TeamId, "{{team_id}}");
+  assertEquals(TriggerContext.Type, "{{type}}");
+});
 
 Deno.test("TriggerContextData Objects allow property access or string references", async (t) => {
   const { Shortcut, Event } = TriggerContextData;


### PR DESCRIPTION
###  Summary

This introduces the `TriggerContext` object discussed in [this PR comment](https://github.com/slackapi/deno-slack-api/pull/69#discussion_r1177118333) and resurfaces `TriggerContextData` via `TriggerContext.Data`

### Testing
Import this `TriggerContext` object into your trigger file and attempt to use it in replacement of any use of templatized strings (ex. `"{{data.interactivity}}"`)

```ts
import { Trigger } from "deno-slack-api/types.ts";
import { TriggerContext, TriggerEventTypes } from "deno-slack-api/mod.ts";
import SubmitIssueWorkflow from "../workflows/submit_issue.ts";

const submitIssue: Trigger<typeof SubmitIssueWorkflow.definition> = {
  type: TriggerTypes.Event,
  name: "Submit an issue",
  description: "Submit an issue to the channel",
  workflow: "#/workflows/submit_issue",
  event: {
    event_type: TriggerEventTypes.ReactionAdded,
    channel_ids: ["C012345T"],
  },
  inputs: {
    channel: {
      value: TriggerContext.Data.Event.ReactionAdded.channel_id,
    },
    team_id: { value: TriggerContext.TeamId },
    enterprise_id: { value: TriggerContext.EnterpriseId },
    event_id: { value: TriggerContext.EventId },
    event_timestamp: { value: TriggerContext.EventTimestamp },
    type: { value: TriggerContext.Type },
  },
};
```

If you're going to test this end to end, be aware that `TriggerContext` values may be returned as `null` and cause runtime failures if being used in a non-nullable field.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
