### PR TITLE
Export TriggerContextData again

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,7 +2,10 @@ import { BaseSlackAPIClient } from "./base-client.ts";
 import { SlackAPIOptions } from "./types.ts";
 import { ProxifyAndTypeClient } from "./api-proxy.ts";
 
-export { TriggerTypes } from "./typed-method-types/workflows/triggers/mod.ts";
+export {
+  TriggerContextData,
+  TriggerTypes,
+} from "./typed-method-types/workflows/triggers/mod.ts";
 export { TriggerEventTypes } from "./typed-method-types/workflows/triggers/trigger-event-types.ts";
 
 export const SlackAPI = (token: string, options: SlackAPIOptions = {}) => {

--- a/src/typed-method-types/workflows/triggers/mod.ts
+++ b/src/typed-method-types/workflows/triggers/mod.ts
@@ -64,7 +64,7 @@ export const TriggerContextData = {
    */
   Shortcut: ShortcutTriggerContextData,
   /**
-   * Data available from the variety of different eventr triggers for use in workflow inputs.
+   * Data available from the variety of different event triggers for use in workflow inputs.
    */
   Event: EventTriggerContextData,
 } as const;


### PR DESCRIPTION
###  Summary

We've decided to hold off on enumerating the other parts of TriggerContext in #72 so we're going to just surface `TriggerContextData` directly now

### Testing
Import this `TriggerContextData` object into your trigger file and attempt to use it in replacement of any use of templatized strings (ex. `"{{data.interactivity}}"`)

```ts
import { Trigger } from "deno-slack-api/types.ts";
import { TriggerContextData, TriggerEventTypes } from "deno-slack-api/mod.ts";
import SubmitIssueWorkflow from "../workflows/submit_issue.ts";

const submitIssue: Trigger<typeof SubmitIssueWorkflow.definition> = {
  type: TriggerTypes.Event,
  name: "Submit an issue",
  description: "Submit an issue to the channel",
  workflow: "#/workflows/submit_issue",
  event: {
    event_type: TriggerEventTypes.ReactionAdded,
    channel_ids: ["C012345T"],
  },
  inputs: {
    channel: {
      value: TriggerContextData.Event.ReactionAdded.channel_id,
    },
  },
};
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
