### PR TITLE
Add a GitHub Action to build this library for npm compatibility.

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,31 @@
+# This workflow runs a test build for npm against changes on main or PRs
+
+name: NPM Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Actions checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+          registry-url: https://registry.npmjs.org/
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run build_npm.ts
+        run: deno run -A scripts/build_npm.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 scripts/api_spec.json
 .coverage
 lcov.info
+npm/

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,0 +1,47 @@
+// ex. scripts/build_npm.ts
+import { build, emptyDir } from "https://deno.land/x/dnt@0.34.0/mod.ts";
+
+await emptyDir("./npm");
+
+await build({
+  typeCheck: false,
+  test: false,
+  entryPoints: ["./src/mod.ts"],
+  outDir: "./npm",
+  // ensures that the emitted package is compatible with node v14 later
+  compilerOptions: {
+    lib: ["es2022.error"], // fix ErrorOptions not exported in ES2020
+    target: "ES2020",
+  },
+  shims: {
+    // see JS docs for overview and more options
+    deno: true,
+    // Shim fetch, File, FormData, Headers, Request, and Response
+    undici: true,
+  },
+  package: {
+    // package.json properties
+    name: "@slack/deno-slack-api",
+    version: Deno.args[0],
+    description:
+      "Official library for using Deno Slack API client in node Slack apps",
+    license: "MIT",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/slackapi/deno-slack-api.git",
+    },
+    bugs: {
+      url: "https://github.com/slackapi/deno-slack-api/issues",
+    },
+    // sets the minimum engine to node v14
+    // as of writing, dnt transpilation-generated code
+    // seems to only be able to successfully compile as far back ES2020
+    engines: {
+      "node": ">=14.20.1",
+      "npm": ">=6.14.15",
+    },
+  },
+});
+
+// post build steps
+Deno.copyFileSync("README.md", "npm/README.md");

--- a/src/typed-method-types/workflows/triggers/inputs.ts
+++ b/src/typed-method-types/workflows/triggers/inputs.ts
@@ -48,7 +48,7 @@ type PopulatedInputs<Params extends InputParameterSchema> = {
  * Returns an object where any string can be set to a valid WorkflowInput value
  */
 type InputSchema<Params extends InputParameterSchema> = Params extends
-  InputParameterSchema ? 
+  InputParameterSchema ?
     & { [k in keyof Params["properties"]]?: WorkflowInput }
     & { [k in Params["required"][number]]: WorkflowInput }
   : Record<string, WorkflowInput>;


### PR DESCRIPTION
In order to prevent failures when creating an npm-compatible build of the deno-slack-sdk repo at the moment of integrating with deno-slack-api, we introduce the npm build in this repo too, to gain earlier awareness about any potential node compatibility issues.

Questions:

- [ ] is there any reason to specifically run the npm build on a mac container in CI? I imagine the linux container is faster.