### PR TITLE
Update user agent

### DIFF
--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -7,7 +7,6 @@ import {
   mf,
 } from "./dev_deps.ts";
 import { SlackAPI } from "./mod.ts";
-import { serializeData } from "./base-client.ts";
 import { HttpError } from "./deps.ts";
 
 Deno.test("SlackAPI class", async (t) => {
@@ -367,41 +366,6 @@ Deno.test("SlackAPI class", async (t) => {
   );
 
   mf.uninstall();
-});
-
-Deno.test("serializeData helper function", async (t) => {
-  await t.step(
-    "should serialize string values as strings and return a URLSearchParams object",
-    () => {
-      assertEquals(
-        serializeData({ "batman": "robin" }).toString(),
-        "batman=robin",
-      );
-    },
-  );
-  await t.step(
-    "should serialize non-string values as JSON-encoded strings and return a URLSearchParams object",
-    () => {
-      assertEquals(
-        serializeData({ "hockey": { "good": true, "awesome": "yes" } })
-          .toString(),
-        "hockey=%7B%22good%22%3Atrue%2C%22awesome%22%3A%22yes%22%7D",
-      );
-    },
-  );
-  await t.step(
-    "should not serialize undefined values",
-    () => {
-      assertEquals(
-        serializeData({
-          "hockey": { "good": true, "awesome": "yes" },
-          "baseball": undefined,
-        })
-          .toString(),
-        "hockey=%7B%22good%22%3Atrue%2C%22awesome%22%3A%22yes%22%7D",
-      );
-    },
-  );
 });
 
 Deno.test("SlackApi.setSlackApiUrl()", async (t) => {

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -28,7 +28,7 @@ Deno.test("SlackAPI class", async (t) => {
         await t.step("should call the default API URL", async () => {
           mf.mock("POST@/api/chat.postMessage", (req: Request) => {
             assertEquals(req.url, "https://slack.com/api/chat.postMessage");
-            assertExists(req.headers.has("User-Agent"));
+            assertExists(req.headers.has("user-agent"));
             return new Response('{"ok":true}');
           });
 
@@ -42,7 +42,7 @@ Deno.test("SlackAPI class", async (t) => {
           async () => {
             mf.mock("POST@/api/chat.postMessage", (req: Request) => {
               assertEquals(req.headers.get("authorization"), "Bearer override");
-              assertExists(req.headers.has("User-Agent"));
+              assertExists(req.headers.has("user-agent"));
               return new Response('{"ok":true}');
             });
 

--- a/src/api_test.ts
+++ b/src/api_test.ts
@@ -1,5 +1,6 @@
 import {
   assertEquals,
+  assertExists,
   assertInstanceOf,
   assertRejects,
   isHttpError,
@@ -27,6 +28,7 @@ Deno.test("SlackAPI class", async (t) => {
         await t.step("should call the default API URL", async () => {
           mf.mock("POST@/api/chat.postMessage", (req: Request) => {
             assertEquals(req.url, "https://slack.com/api/chat.postMessage");
+            assertExists(req.headers.has("User-Agent"));
             return new Response('{"ok":true}');
           });
 
@@ -40,6 +42,7 @@ Deno.test("SlackAPI class", async (t) => {
           async () => {
             mf.mock("POST@/api/chat.postMessage", (req: Request) => {
               assertEquals(req.headers.get("authorization"), "Bearer override");
+              assertExists(req.headers.has("User-Agent"));
               return new Response('{"ok":true}');
             });
 

--- a/src/base-client-helpers.ts
+++ b/src/base-client-helpers.ts
@@ -1,0 +1,46 @@
+const API_VERSION_REGEX = /deno_slack_api@(.*)\//;
+
+export function getUserAgent() {
+  const userAgents = [];
+  userAgents.push(`Deno/${Deno.version.deno}`);
+  userAgents.push(`OS/${Deno.build.os}`);
+  userAgents.push(
+    `deno-slack-api/${_internals.getModuleVersion()}`,
+  );
+  return userAgents.join(" ");
+}
+
+function getModuleVersion(): string {
+  const url = _internals.getModuleUrl();
+  if (url.host === "deno.land") {
+    const regVersion = url.pathname.match(API_VERSION_REGEX)?.at(1);
+    if (regVersion) return regVersion;
+  }
+  return "unknown";
+}
+
+function getModuleUrl(): URL {
+  return new URL(import.meta.url);
+}
+
+// Serialize an object into a string so as to be compatible with x-www-form-urlencoded payloads
+export function serializeData(data: Record<string, unknown>): URLSearchParams {
+  const encodedData: Record<string, string> = {};
+  Object.entries(data).forEach(([key, value]) => {
+    // Objects/arrays, numbers and booleans get stringified
+    // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
+    // Inspired by https://github.com/slackapi/node-slack-sdk/blob/%40slack/web-api%406.7.2/packages/web-api/src/WebClient.ts#L452-L528
+
+    // Skip properties with undefined values.
+    if (value === undefined) return;
+
+    const serializedValue: string = typeof value !== "string"
+      ? JSON.stringify(value)
+      : value;
+    encodedData[key] = serializedValue;
+  });
+
+  return new URLSearchParams(encodedData);
+}
+
+export const _internals = { getModuleVersion, getModuleUrl };

--- a/src/base-client-helpers.ts
+++ b/src/base-client-helpers.ts
@@ -12,7 +12,7 @@ export function getUserAgent() {
 
 function getModuleVersion(): string | undefined {
   const url = _internals.getModuleUrl();
-  // insure this module is remote
+  // Insure this module is sourced from https://deno.land/x/deno_slack_api
   if (url.host === "deno.land") {
     return url.pathname.match(API_VERSION_REGEX)?.at(1);
   }

--- a/src/base-client-helpers.ts
+++ b/src/base-client-helpers.ts
@@ -1,4 +1,4 @@
-const API_VERSION_REGEX = /deno_slack_api@(.*)\//;
+const API_VERSION_REGEX = /\/deno_slack_api@(.*)\//;
 
 export function getUserAgent() {
   const userAgents = [];
@@ -10,13 +10,13 @@ export function getUserAgent() {
   return userAgents.join(" ");
 }
 
-function getModuleVersion(): string {
+function getModuleVersion(): string | undefined {
   const url = _internals.getModuleUrl();
+  // insure this module is remote
   if (url.host === "deno.land") {
-    const regVersion = url.pathname.match(API_VERSION_REGEX)?.at(1);
-    if (regVersion) return regVersion;
+    return url.pathname.match(API_VERSION_REGEX)?.at(1);
   }
-  return "unknown";
+  return undefined;
 }
 
 function getModuleUrl(): URL {

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -32,7 +32,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
         const moduleVersion = _internals.getModuleVersion();
 
         assertSpyCalls(getModuleUrlStub, 1);
-        assertEquals(moduleVersion, "unknown");
+        assertEquals(moduleVersion, undefined);
       } finally {
         getModuleUrlStub.restore();
       }
@@ -49,7 +49,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
         const moduleVersion = _internals.getModuleVersion();
 
         assertSpyCalls(getModuleUrlStub, 1);
-        assertEquals(moduleVersion, "unknown");
+        assertEquals(moduleVersion, undefined);
       } finally {
         getModuleUrlStub.restore();
       }
@@ -61,7 +61,7 @@ Deno.test(getUserAgent.name, async (t) => {
   await t.step(
     "should return the user agent with expected output",
     () => {
-      const expectedVersion = "unknown";
+      const expectedVersion = undefined;
       const getModuleUrlStub = stub(_internals, "getModuleVersion", () => {
         return expectedVersion;
       });
@@ -72,7 +72,7 @@ Deno.test(getUserAgent.name, async (t) => {
         assertSpyCalls(getModuleUrlStub, 1);
         assertEquals(
           userAgent,
-          `Deno/${Deno.version.deno} OS/${Deno.build.os} deno-slack-api/${expectedVersion}`,
+          `Deno/${Deno.version.deno} OS/${Deno.build.os} deno-slack-api/undefined`,
         );
       } finally {
         getModuleUrlStub.restore();

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -62,7 +62,7 @@ Deno.test(`base-client-helpers.${_internals.getModuleVersion.name}`, async (t) =
 
 Deno.test(`base-client-helpers.${getUserAgent.name}`, async (t) => {
   await t.step(
-    "should return the user agent with expected output",
+    "should return the user agent with deno version, OS name and undefined deno-slack-api version",
     () => {
       const expectedVersion = undefined;
       const getModuleUrlStub = stub(_internals, "getModuleVersion", () => {
@@ -84,7 +84,7 @@ Deno.test(`base-client-helpers.${getUserAgent.name}`, async (t) => {
   );
 
   await t.step(
-    "should return the user agent with module version",
+    "should return the user agent with deno version, OS name and deno-slack-api version",
     () => {
       const expectedVersion = "2.1.0";
       const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -40,7 +40,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
   );
 
   await t.step(
-    "should return the unknown if the module version is invalid",
+    "should return undefined if the regex used to parse deno_slack_api@x.x.x fails",
     () => {
       const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
         return new URL("https://deno.land/x/deno_slack_sdk@2.1.0/mod.ts)");

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.185.0/testing/asserts.ts";
-import { _internals } from "./base-client.ts";
+import { _internals, getUserAgent } from "./base-client-helpers.ts";
+import { serializeData } from "./base-client-helpers.ts";
 import { assertSpyCalls, stub } from "./dev_deps.ts";
 
 Deno.test(_internals.getModuleVersion.name, async (t) => {
@@ -56,7 +57,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
   );
 });
 
-Deno.test(_internals.getUserAgent.name, async (t) => {
+Deno.test(getUserAgent.name, async (t) => {
   await t.step(
     "should return the user agent with expected output",
     () => {
@@ -66,7 +67,7 @@ Deno.test(_internals.getUserAgent.name, async (t) => {
       });
 
       try {
-        const userAgent = _internals.getUserAgent();
+        const userAgent = getUserAgent();
 
         assertSpyCalls(getModuleUrlStub, 1);
         assertEquals(
@@ -90,7 +91,7 @@ Deno.test(_internals.getUserAgent.name, async (t) => {
       });
 
       try {
-        const userAgent = _internals.getUserAgent();
+        const userAgent = getUserAgent();
 
         assertSpyCalls(getModuleUrlStub, 1);
         assertEquals(
@@ -100,6 +101,41 @@ Deno.test(_internals.getUserAgent.name, async (t) => {
       } finally {
         getModuleUrlStub.restore();
       }
+    },
+  );
+});
+
+Deno.test(`${serializeData.name} helper function`, async (t) => {
+  await t.step(
+    "should serialize string values as strings and return a URLSearchParams object",
+    () => {
+      assertEquals(
+        serializeData({ "batman": "robin" }).toString(),
+        "batman=robin",
+      );
+    },
+  );
+  await t.step(
+    "should serialize non-string values as JSON-encoded strings and return a URLSearchParams object",
+    () => {
+      assertEquals(
+        serializeData({ "hockey": { "good": true, "awesome": "yes" } })
+          .toString(),
+        "hockey=%7B%22good%22%3Atrue%2C%22awesome%22%3A%22yes%22%7D",
+      );
+    },
+  );
+  await t.step(
+    "should not serialize undefined values",
+    () => {
+      assertEquals(
+        serializeData({
+          "hockey": { "good": true, "awesome": "yes" },
+          "baseball": undefined,
+        })
+          .toString(),
+        "hockey=%7B%22good%22%3Atrue%2C%22awesome%22%3A%22yes%22%7D",
+      );
     },
   );
 });

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -1,9 +1,12 @@
 import { assertEquals } from "https://deno.land/std@0.185.0/testing/asserts.ts";
-import { _internals, getUserAgent } from "./base-client-helpers.ts";
-import { serializeData } from "./base-client-helpers.ts";
+import {
+  _internals,
+  getUserAgent,
+  serializeData,
+} from "./base-client-helpers.ts";
 import { assertSpyCalls, stub } from "./dev_deps.ts";
 
-Deno.test(_internals.getModuleVersion.name, async (t) => {
+Deno.test(`base-client-helpers.${_internals.getModuleVersion.name}`, async (t) => {
   await t.step(
     "should return the version if the module is sourced from deno.land",
     () => {
@@ -57,7 +60,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
   );
 });
 
-Deno.test(getUserAgent.name, async (t) => {
+Deno.test(`base-client-helpers.${getUserAgent.name}`, async (t) => {
   await t.step(
     "should return the user agent with expected output",
     () => {

--- a/src/base-client-helpers_test.ts
+++ b/src/base-client-helpers_test.ts
@@ -23,7 +23,7 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
   );
 
   await t.step(
-    "should return the unknown if the module is not sourced from deno.land",
+    "should return undefined if the module is not sourced from deno.land",
     () => {
       const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
         return new URL("file:///hello/world.ts)");

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -5,6 +5,7 @@ import {
   SlackAPIOptions,
 } from "./types.ts";
 import { createHttpError, HttpError } from "./deps.ts";
+import { getUserAgent, serializeData } from "./base-client-helpers.ts";
 
 export class BaseSlackAPIClient implements BaseSlackClient {
   #token?: string;
@@ -42,7 +43,7 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       headers: {
         "Authorization": `Bearer ${token}`,
         "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": _internals.getUserAgent(),
+        "User-Agent": getUserAgent(),
       },
       body,
     });
@@ -62,7 +63,7 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "User-Agent": _internals.getUserAgent(),
+        "User-Agent": getUserAgent(),
       },
       body: JSON.stringify(data),
     });
@@ -90,48 +91,3 @@ export class BaseSlackAPIClient implements BaseSlackClient {
     };
   }
 }
-
-// Serialize an object into a string so as to be compatible with x-www-form-urlencoded payloads
-export function serializeData(data: Record<string, unknown>): URLSearchParams {
-  const encodedData: Record<string, string> = {};
-  Object.entries(data).forEach(([key, value]) => {
-    // Objects/arrays, numbers and booleans get stringified
-    // Slack API accepts JSON-stringified-and-url-encoded payloads for objects/arrays
-    // Inspired by https://github.com/slackapi/node-slack-sdk/blob/%40slack/web-api%406.7.2/packages/web-api/src/WebClient.ts#L452-L528
-
-    // Skip properties with undefined values.
-    if (value === undefined) return;
-
-    const serializedValue: string = typeof value !== "string"
-      ? JSON.stringify(value)
-      : value;
-    encodedData[key] = serializedValue;
-  });
-
-  return new URLSearchParams(encodedData);
-}
-
-function getUserAgent() {
-  const userAgents = [];
-  userAgents.push(`Deno/${Deno.version.deno}`);
-  userAgents.push(`OS/${Deno.build.os}`);
-  userAgents.push(
-    `deno-slack-api/${_internals.getModuleVersion()}`,
-  );
-  return userAgents.join(" ");
-}
-
-function getModuleVersion(): string {
-  const url = _internals.getModuleUrl();
-  if (url.host === "deno.land") {
-    const regVersion = url.pathname.match(/deno_slack_api@(?<v>.*)\//)?.[1];
-    if (regVersion) return regVersion;
-  }
-  return "unknown";
-}
-
-function getModuleUrl(): URL {
-  return new URL(import.meta.url);
-}
-
-export const _internals = { getUserAgent, getModuleVersion, getModuleUrl };

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -47,7 +47,6 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       },
       body,
     });
-
     if (!response.ok) {
       throw await this.createHttpError(response);
     }

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -127,6 +127,7 @@ function getImportVersion() {
     if (url.protocol === "file:") {
       console.log("this module was loaded locally");
     }
+    return url.host;
   } catch (error) {
     throw Error("no module found");
   }

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -37,7 +37,7 @@ export class BaseSlackAPIClient implements BaseSlackClient {
     const body = serializeData(data);
 
     const token = data.token || this.#token || "";
-    const request = new Request(url, {
+    const response = await fetch(url, {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${token}`,
@@ -46,7 +46,6 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       },
       body,
     });
-    const response = await fetch(request);
 
     if (!response.ok) {
       throw await this.createHttpError(response);

--- a/src/base-client.ts
+++ b/src/base-client.ts
@@ -42,7 +42,7 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       headers: {
         "Authorization": `Bearer ${token}`,
         "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": getUserAgent(),
+        "User-Agent": _internals.getUserAgent(),
       },
       body,
     });
@@ -63,6 +63,7 @@ export class BaseSlackAPIClient implements BaseSlackClient {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "User-Agent": _internals.getUserAgent(),
       },
       body: JSON.stringify(data),
     });
@@ -116,19 +117,22 @@ function getUserAgent() {
   userAgents.push(`Deno/${Deno.version.deno}`);
   userAgents.push(`OS/${Deno.build.os}`);
   userAgents.push(
-    `deno-slack-api/${getImportVersion()}`,
+    `deno-slack-api/${_internals.getModuleVersion()}`,
   );
   return userAgents.join(" ");
 }
 
-function getImportVersion() {
-  try {
-    const url = new URL(import.meta.url);
-    if (url.protocol === "file:") {
-      console.log("this module was loaded locally");
-    }
-    return url.host;
-  } catch (error) {
-    throw Error("no module found");
+function getModuleVersion(): string {
+  const url = _internals.getModuleUrl();
+  if (url.host === "deno.land") {
+    const regVersion = url.pathname.match(/deno_slack_api@(?<v>.*)\//)?.[1];
+    if (regVersion) return regVersion;
   }
+  return "unknown";
 }
+
+function getModuleUrl(): URL {
+  return new URL(import.meta.url);
+}
+
+export const _internals = { getUserAgent, getModuleVersion, getModuleUrl };

--- a/src/base-client_test.ts
+++ b/src/base-client_test.ts
@@ -37,6 +37,23 @@ Deno.test(_internals.getModuleVersion.name, async (t) => {
       }
     },
   );
+
+  await t.step(
+    "should return the unknown if the module version is invalid",
+    () => {
+      const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
+        return new URL("https://deno.land/x/deno_slack_sdk@2.1.0/mod.ts)");
+      });
+      try {
+        const moduleVersion = _internals.getModuleVersion();
+
+        assertSpyCalls(getModuleUrlStub, 1);
+        assertEquals(moduleVersion, "unknown");
+      } finally {
+        getModuleUrlStub.restore();
+      }
+    },
+  );
 });
 
 Deno.test(_internals.getUserAgent.name, async (t) => {

--- a/src/base-client_test.ts
+++ b/src/base-client_test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "https://deno.land/std@0.185.0/testing/asserts.ts";
+import { _internals } from "./base-client.ts";
+import { assertSpyCalls, stub } from "./dev_deps.ts";
+
+Deno.test(_internals.getModuleVersion.name, async (t) => {
+  await t.step(
+    "should return the version if the module is sourced from deno.land",
+    () => {
+      const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
+        return new URL("https://deno.land/x/deno_slack_api@2.1.0/mod.ts)");
+      });
+
+      try {
+        const moduleVersion = _internals.getModuleVersion();
+
+        assertSpyCalls(getModuleUrlStub, 1);
+        assertEquals(moduleVersion, "2.1.0");
+      } finally {
+        getModuleUrlStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "should return the unknown if the module is not sourced from deno.land",
+    () => {
+      const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
+        return new URL("file:///hello/world.ts)");
+      });
+      try {
+        const moduleVersion = _internals.getModuleVersion();
+
+        assertSpyCalls(getModuleUrlStub, 1);
+        assertEquals(moduleVersion, "unknown");
+      } finally {
+        getModuleUrlStub.restore();
+      }
+    },
+  );
+});
+
+Deno.test(_internals.getUserAgent.name, async (t) => {
+  await t.step(
+    "should return the user agent with expected output",
+    () => {
+      const expectedVersion = "unknown";
+      const getModuleUrlStub = stub(_internals, "getModuleVersion", () => {
+        return expectedVersion;
+      });
+
+      try {
+        const userAgent = _internals.getUserAgent();
+
+        assertSpyCalls(getModuleUrlStub, 1);
+        assertEquals(
+          userAgent,
+          `Deno/${Deno.version.deno} OS/${Deno.build.os} deno-slack-api/${expectedVersion}`,
+        );
+      } finally {
+        getModuleUrlStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "should return the user agent with module version",
+    () => {
+      const expectedVersion = "2.1.0";
+      const getModuleUrlStub = stub(_internals, "getModuleUrl", () => {
+        return new URL(
+          `https://deno.land/x/deno_slack_api@${expectedVersion}/mod.ts)`,
+        );
+      });
+
+      try {
+        const userAgent = _internals.getUserAgent();
+
+        assertSpyCalls(getModuleUrlStub, 1);
+        assertEquals(
+          userAgent,
+          `Deno/${Deno.version.deno} OS/${Deno.build.os} deno-slack-api/${expectedVersion}`,
+        );
+      } finally {
+        getModuleUrlStub.restore();
+      }
+    },
+  );
+});

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -11,3 +11,7 @@ export {
   afterEach,
   beforeAll,
 } from "https://deno.land/std@0.185.0/testing/bdd.ts";
+export {
+  assertSpyCalls,
+  stub,
+} from "https://deno.land/std@0.185.0/testing/mock.ts";


### PR DESCRIPTION
###  Summary

The goal of this PR is to provide slack with a more meaningful `user-agent` information, when users make http requests to Slack.

Previously Deno would populate this header with `Deno/1.x.x` describing the users Deno version, now it will be populated with `Deno/1.x.x OS/<user os> deno-slack-api/<version | undefined>`

- [user os list](https://deno.land/api?s=Deno.build)

#### Testing

The unit tests try to cover all edge cases

Manual testing is tricky since the module must be released in order to get a successful version.

To test an undefined api version use the following to start a local server
```ts
const server = Deno.listen({ port: 8080 });
console.log(`HTTP webserver running.  Access it at:  http://localhost:8080/`);

for await (const conn of server) {
  serveHttp(conn);
}

async function serveHttp(conn: Deno.Conn) {

  const httpConn = Deno.serveHttp(conn);

  for await (const requestEvent of httpConn) {
	  console.log(requestEvent.request.headers.get("user-agent"));
    requestEvent.respondWith(
      new Response(`{}`, {
        status: 200,
      }),
    );
  }
}
```

Then use the following to send a request
```ts
import { SlackAPI } from "https://raw.githubusercontent.com/slackapi/deno-slack-api/update-user-agent/src/mod.ts"

const client = SlackAPI("test-token",
{
	slackApiUrl: "http://localhost:8080/"
});

await client.api.test();
```

The command line should print out something like `Deno/1.36.0 OS/darwin deno-slack-api/undefined`

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
