### PR TITLE
feat: Add datastore count API

### DIFF
--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -187,8 +187,18 @@ export type DatastoreQueryArgs<
      * @description The name of the datastore
      */
     datastore: Schema["name"];
+    /**
+     * @description A query filter expression
+     * @see {@link https://api.slack.com/automation/datastores-retrieve#filter-expressions}.
+     */
     expression?: string;
+    /**
+     * @description A map of attributes referenced in expression
+     */
     "expression_attributes"?: Record<string, string>;
+    /**
+     * @description A map of values referenced in expression
+     */
     "expression_values"?: Record<string, string | boolean | number>;
   };
 
@@ -217,8 +227,18 @@ export type DatastoreCountArgs<
      * @description The name of the datastore
      */
     datastore: Schema["name"];
+    /**
+     * @description A query filter expression
+     * @see {@link https://api.slack.com/automation/datastores-retrieve#filter-expressions}.
+     */
     expression?: string;
+    /**
+     * @description A map of attributes referenced in expression
+     */
     "expression_attributes"?: Record<string, string>;
+    /**
+     * @description A map of values referenced in expression
+     */
     "expression_values"?: Record<string, string | boolean | number>;
   };
 

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -208,6 +208,35 @@ export type DatastoreQueryResponse<
     items: DatastoreItem<Schema>[];
   };
 
+export type DatastoreCountArgs<
+  Schema extends DatastoreSchema,
+> =
+  & BaseMethodArgs
+  & {
+    /**
+     * @description The name of the datastore
+     */
+    datastore: Schema["name"];
+    expression?: string;
+    "expression_attributes"?: Record<string, string>;
+    "expression_values"?: Record<string, string | boolean | number>;
+  };
+
+export type DatastoreCountResponse<
+  Schema extends DatastoreSchema,
+> =
+  & BaseResponse
+  & {
+    /**
+     * @description The name of the datastore
+     */
+    datastore: Schema["name"];
+    /**
+     * @description The number of items matching your query
+     */
+    count: number;
+  };
+
 export type DatastoreDeleteArgs<
   Schema extends DatastoreSchema,
 > =
@@ -293,6 +322,11 @@ export type AppsDatastoreQuery = {
     args: DatastoreQueryArgs<Schema>,
   ): Promise<DatastoreQueryResponse<Schema>>;
 };
+export type AppsDatastoreCount = {
+  <Schema extends DatastoreSchema>(
+    args: DatastoreCountArgs<Schema>,
+  ): Promise<DatastoreCountResponse<Schema>>;
+};
 export type AppsDatastoreDelete = {
   <Schema extends DatastoreSchema>(
     args: DatastoreDeleteArgs<Schema>,
@@ -368,6 +402,7 @@ export type TypedAppsMethodTypes = {
       bulkPut: AppsDatastoreBulkPut;
       update: AppsDatastoreUpdate;
       query: AppsDatastoreQuery;
+      count: AppsDatastoreCount;
       delete: AppsDatastoreDelete;
       bulkDelete: AppsDatastoreBulkDelete;
     };

--- a/src/typed-method-types/apps.ts
+++ b/src/typed-method-types/apps.ts
@@ -6,6 +6,22 @@ import {
 } from "../types.ts";
 
 // apps.datastore Types
+type DynamoQueryArgs = {
+  /**
+   * @description A query filter expression
+   * @see {@link https://api.slack.com/automation/datastores-retrieve#filter-expressions}.
+   */
+  expression?: string;
+  /**
+   * @description A map of attributes referenced in `expression`
+   */
+  "expression_attributes"?: Record<string, string>;
+  /**
+   * @description A map of values referenced in `expression`
+   */
+  "expression_values"?: Record<string, string | boolean | number>;
+};
+
 export type DatastoreSchema = {
   name: string;
   // deno-lint-ignore no-explicit-any
@@ -182,24 +198,12 @@ export type DatastoreQueryArgs<
 > =
   & BaseMethodArgs
   & CursorPaginationArgs
+  & DynamoQueryArgs
   & {
     /**
      * @description The name of the datastore
      */
     datastore: Schema["name"];
-    /**
-     * @description A query filter expression
-     * @see {@link https://api.slack.com/automation/datastores-retrieve#filter-expressions}.
-     */
-    expression?: string;
-    /**
-     * @description A map of attributes referenced in expression
-     */
-    "expression_attributes"?: Record<string, string>;
-    /**
-     * @description A map of values referenced in expression
-     */
-    "expression_values"?: Record<string, string | boolean | number>;
   };
 
 export type DatastoreQueryResponse<
@@ -222,24 +226,12 @@ export type DatastoreCountArgs<
   Schema extends DatastoreSchema,
 > =
   & BaseMethodArgs
+  & DynamoQueryArgs
   & {
     /**
      * @description The name of the datastore
      */
     datastore: Schema["name"];
-    /**
-     * @description A query filter expression
-     * @see {@link https://api.slack.com/automation/datastores-retrieve#filter-expressions}.
-     */
-    expression?: string;
-    /**
-     * @description A map of attributes referenced in expression
-     */
-    "expression_attributes"?: Record<string, string>;
-    /**
-     * @description A map of values referenced in expression
-     */
-    "expression_values"?: Record<string, string | boolean | number>;
   };
 
 export type DatastoreCountResponse<

--- a/src/typed-method-types/mod.ts
+++ b/src/typed-method-types/mod.ts
@@ -20,6 +20,7 @@ export const methodsWithCustomTypes = [
   "apps.datastore.bulkPut",
   "apps.datastore.update",
   "apps.datastore.query",
+  "apps.datastore.count",
   "apps.auth.external.get",
   "apps.auth.external.delete",
   "chat.postMessage",

--- a/src/typed-method-types/typed-method-tests.ts
+++ b/src/typed-method-types/typed-method-tests.ts
@@ -12,6 +12,7 @@ Deno.test("Custom Type Methods are valid functions", () => {
   assertEquals(typeof client.apps.datastore.bulkPut, "function");
   assertEquals(typeof client.apps.datastore.update, "function");
   assertEquals(typeof client.apps.datastore.query, "function");
+  assertEquals(typeof client.apps.datastore.count, "function");
   assertEquals(typeof client.apps.auth.external.get, "function");
   assertEquals(typeof client.apps.auth.external.delete, "function");
   assertEquals(typeof client.workflows.triggers.create, "function");


### PR DESCRIPTION
### Summary

Add support for [Count API](https://slack-pde.slack.com/archives/C08B6H5U4/p1708545988043419) commands for datastores.

### testing

Created an app with a datastore, and used the new API to count the number of items in the datastore.
```
// Example function
export const CountFunctionDefinition = DefineFunction({
  callback_id: "count_function",
  title: "count function",
  description: "Count all rows in datastore",
  source_file: "functions/count_function.ts",
  input_parameters: {
    properties: {
      datastore: {
        type: Schema.types.string,
        description: "Name of datastore to count",
      },
    },
    required: ["datastore"],
  }
});

export default SlackFunction(
  CountFunctionDefinition,
  async ({ client, inputs }) => {
    const res = await client.apps.datastore.count({
      datastore: inputs.datastore,
    });
    if (!res.ok) {
      const errorMsg = `(Error detail: ${res.error})`;
      console.log(errorMsg);
      return { error: errorMsg };
    }
    return { outputs: { count: res.count.toString() } };
  },
);

```

### Special notes
The API is behind a [toggle](https://houston.tinyspeck.com/experiments/6657322849767) which is only enabled for dev right now. The plan is to dial up the toggle with the next SDK/CLI release.
PR for CLI changes: https://github.com/slackapi/slack-cli/pull/1262
### Requirements <!-- place an `x` in each `[ ]` -->

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [X] I've ran `deno task test` after making the changes.
