### PR TITLE
Add new incoming canvas APIs

### DIFF
--- a/scripts/src/public-api-methods.ts
+++ b/scripts/src/public-api-methods.ts
@@ -103,6 +103,12 @@ export const getPublicAPIMethods = () => {
     "calls.update",
     "calls.participants.add",
     "calls.participants.remove",
+    "canvases.access.delete",
+    "canvases.access.set",
+    "canvases.create",
+    "canvases.delete",
+    "canvases.edit",
+    "canvases.sections.lookup",
     "chat.delete",
     "chat.deleteScheduledMessage",
     "chat.getPermalink",
@@ -116,6 +122,7 @@ export const getPublicAPIMethods = () => {
     "conversations.acceptSharedInvite",
     "conversations.approveSharedInvite",
     "conversations.archive",
+    "conversations.canvases.create",
     "conversations.close",
     "conversations.create",
     "conversations.declineSharedInvite",
@@ -161,6 +168,8 @@ export const getPublicAPIMethods = () => {
     "files.remote.remove",
     "files.remote.share",
     "files.remote.update",
+    "functions.completeError",
+    "functions.completeSuccess",
     "migration.exchange",
     "oauth.access",
     "oauth.v2.access",
@@ -223,15 +232,8 @@ export const getPublicAPIMethods = () => {
     "workflows.updateStep",
   ];
 
-  // next gen platform methods we want available but aren't listed quite yet
-  const nextGenPlatformMethods = [
-    "functions.completeError",
-    "functions.completeSuccess",
-  ];
-
   const methodsSet = new Set([
     ...publicAPIMethods,
-    ...nextGenPlatformMethods,
   ]);
 
   methodsWithCustomTypes.forEach((customMethod) => {

--- a/src/generated/method-types/api_method_types_test.ts
+++ b/src/generated/method-types/api_method_types_test.ts
@@ -139,6 +139,12 @@ Deno.test("SlackAPIMethodsType generated types", () => {
   assertEquals(typeof client.calls.participants.add, "function");
   assertEquals(typeof client.calls.participants.remove, "function");
   assertEquals(typeof client.calls.update, "function");
+  assertEquals(typeof client.canvases.access.delete, "function");
+  assertEquals(typeof client.canvases.access.set, "function");
+  assertEquals(typeof client.canvases.create, "function");
+  assertEquals(typeof client.canvases.delete, "function");
+  assertEquals(typeof client.canvases.edit, "function");
+  assertEquals(typeof client.canvases.sections.lookup, "function");
   assertEquals(typeof client.chat.delete, "function");
   assertEquals(typeof client.chat.deleteScheduledMessage, "function");
   assertEquals(typeof client.chat.getPermalink, "function");
@@ -151,6 +157,7 @@ Deno.test("SlackAPIMethodsType generated types", () => {
   assertEquals(typeof client.conversations.acceptSharedInvite, "function");
   assertEquals(typeof client.conversations.approveSharedInvite, "function");
   assertEquals(typeof client.conversations.archive, "function");
+  assertEquals(typeof client.conversations.canvases.create, "function");
   assertEquals(typeof client.conversations.close, "function");
   assertEquals(typeof client.conversations.create, "function");
   assertEquals(typeof client.conversations.declineSharedInvite, "function");

--- a/src/generated/method-types/canvases.ts
+++ b/src/generated/method-types/canvases.ts
@@ -1,0 +1,14 @@
+import type { SlackAPIMethod } from "../../types.ts";
+
+export type CanvasesAPIType = {
+  access: {
+    delete: SlackAPIMethod;
+    set: SlackAPIMethod;
+  };
+  create: SlackAPIMethod;
+  delete: SlackAPIMethod;
+  edit: SlackAPIMethod;
+  sections: {
+    lookup: SlackAPIMethod;
+  };
+};

--- a/src/generated/method-types/conversations.ts
+++ b/src/generated/method-types/conversations.ts
@@ -7,6 +7,9 @@ export type ConversationsAPIType = {
   acceptSharedInvite: SlackAPIMethod;
   approveSharedInvite: SlackAPIMethod;
   archive: SlackAPIMethod;
+  canvases: {
+    create: SlackAPIMethod;
+  };
   close: SlackAPIMethod;
   create: SlackAPIMethod;
   declineSharedInvite: SlackAPIMethod;

--- a/src/generated/method-types/mod.ts
+++ b/src/generated/method-types/mod.ts
@@ -5,6 +5,7 @@ import { type AuthAPIType } from "./auth.ts";
 import { type BookmarksAPIType } from "./bookmarks.ts";
 import { type BotsAPIType } from "./bots.ts";
 import { type CallsAPIType } from "./calls.ts";
+import { type CanvasesAPIType } from "./canvases.ts";
 import { type ChatAPIType } from "./chat.ts";
 import { type ConversationsAPIType } from "./conversations.ts";
 import { type DialogAPIType } from "./dialog.ts";
@@ -36,6 +37,7 @@ export type SlackAPIMethodsType = {
   bookmarks: BookmarksAPIType;
   bots: BotsAPIType;
   calls: CallsAPIType;
+  canvases: CanvasesAPIType;
   chat: ChatAPIType;
   conversations: ConversationsAPIType;
   dialog: DialogAPIType;


### PR DESCRIPTION
Also, , no longer consider `functions.*` APIs hidden (since we publicly document them).