### PR TITLE
fix: updating available event trigger data

### DIFF
--- a/src/typed-method-types/workflows/triggers/event-data/channel_archived.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/channel_archived.ts
@@ -11,7 +11,7 @@ export const ChannelArchived = {
    */
   channel_name: "{{data.channel_name}}",
   /**
-   * The channel type for the channel that was archived. Can be one of "public" or "private".
+   * The channel type for the channel that was archived. Can be one of `public`, `private`, `im` or `mpim`.
    */
   channel_type: "{{data.channel_type}}",
   /**

--- a/src/typed-method-types/workflows/triggers/event-data/message_posted.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/message_posted.ts
@@ -3,10 +3,6 @@ import base_trigger_data from "./common-objects/all_triggers.ts";
 export const MessagePosted = {
   ...base_trigger_data,
   /**
-   * A unique identifier for the app that posted the message. Only available when message is posted by an app.
-   */
-  app_id: "{{data.app_id}}",
-  /**
    * A unique identifier for the {@link https://api.slack.com/automation/types#channelid Slack channel} where message was posted.
    */
   channel_id: "{{data.channel_id}}",

--- a/src/typed-method-types/workflows/triggers/event-data/reaction_added.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/reaction_added.ts
@@ -11,13 +11,25 @@ export const ReactionAdded = {
    */
   event_type: "{{data.event_type}}",
   /**
+   * A unique identifier for the {@link https://api.slack.com/automation/types#userid Slack user} who sent the message that was reacted to.
+   */
+  item_user: "{{data.item_user}}",
+  /**
    * A {@link https://api.slack.com/automation/types#message-context Message Context} object representing the message being reacted to.
    */
   message_context: "{{data.message_context}}",
   /**
+   * Link to the message that was reacted to.
+   */
+  message_link: "{{data.message_link}}",
+  /**
    * A unique {@link https://api.slack.com/automation/types#message-ts Slack message timestamp string} indicating when the message being reacted to was sent.
    */
   message_ts: "{{data.message_ts}}",
+  /**
+   * Link to the parent of the message that was reacted to. Only available if reaction was added to a threaded reply.
+   */
+  parent_message_link: "{{data.parent_message_link}}",
   /**
    * A string representing the emoji name.
    */

--- a/src/typed-method-types/workflows/triggers/event-data/user_joined_channel.ts
+++ b/src/typed-method-types/workflows/triggers/event-data/user_joined_channel.ts
@@ -15,10 +15,6 @@ export const UserJoinedChannel = {
    */
   event_type: "{{data.event_type}}",
   /**
-   * A unique identifier for the {@link https://api.slack.com/automation/types#userid Slack user} who invited the member to the channel.
-   */
-  inviter_id: "{{data.inviter_id}}",
-  /**
    * A unique identifier for the {@link https://api.slack.com/automation/types#userid Slack user} who joined the channel.
    */
   user_id: "{{data.user_id}}",


### PR DESCRIPTION
- removes `app_id` from `message_posted` event
- adds `item_user`, `message_link` and `parent_message_link` to `reaction_added` event
- removes `inviter_id` from `user_joined_channel` event

Our public docs on this are here: https://api.slack.com/automation/triggers/event#data