### PR TITLE
ci: pin actions workflow step hashes and use minimum permissions

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,9 +2,11 @@ name: Deno Format, Lint and Unit Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   test:
@@ -14,11 +16,15 @@ jobs:
         # we test on both most recent stable version of deno (v1.x) as well as
         # the version of deno used by Run on Slack (as noted in https://api.slack.com/slackcli/metadata.json)
         deno-version: [v1.x, v1.45.4]
+    permissions:
+      contents: read
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
           deno-version: ${{ matrix.deno-version }}
       - name: Run formatter, linter and tests
@@ -26,7 +32,7 @@ jobs:
       - name: Generate CodeCov-friendly coverage report
         run: deno task generate-lcov
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           file: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -38,9 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Report health score
-        uses: slackapi/slack-health-score@v0
+        uses: slackapi/slack-health-score@d58a419f15cdaff97e9aa7f09f95772830ab66f7 # v0.1.1
         with:
           codecov_token: ${{ secrets.FILS_CODECOV_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -40,7 +40,8 @@ jobs:
   health-score:
     needs: test
     permissions:
-      contents: none
+      checks: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -41,6 +41,7 @@ jobs:
     needs: test
     permissions:
       checks: write
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -40,7 +40,6 @@ jobs:
   health-score:
     needs: test
     permissions:
-      checks: write
       contents: none
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -4,26 +4,31 @@ name: NPM Build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: macos-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Actions checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: latest
           registry-url: https://registry.npmjs.org/
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
           deno-version: v1.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,16 @@ name: Publish
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # The OIDC ID token is used for authentication with JSR.    
+      id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: npx jsr publish

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -3,9 +3,11 @@ name: Samples Integration Type-checking
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   samples:
@@ -22,22 +24,25 @@ jobs:
         # we test on both most recent stable version of deno (v1.x) as well as
         # the version of deno used by Run on Slack (as noted in https://api.slack.com/slackcli/metadata.json)
         deno-version: [v1.x, v1.45.4]
-
+    permissions:
+      contents: read
     steps:
       - name: Setup Deno ${{ matrix.deno-version }}
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Checkout the api
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: ./deno-slack-api
+          persist-credentials: false
       - name: Checkout the ${{ matrix.sample }} sample
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ matrix.sample }}
           path: ./sample
+          persist-credentials: false
 
       - name: Set imports.deno-slack-api/ to ../deno-slack-api/src/ in import_map.json
         run: >


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (4 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.

### Testing

🔍 CI covers most cases, but on publish we might want to be aware of possible changes to these workflows.

### Special notes

🎵 🎺 🦖 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.
