### PR TITLE
test: preserve Content-Type in stubFetch response clone on Deno 2.x

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # we test on both most recent stable version of deno (v1.x) as well as
         # the version of deno used by Run on Slack (as noted in https://api.slack.com/slackcli/metadata.json)

--- a/testing/http.ts
+++ b/testing/http.ts
@@ -35,7 +35,12 @@ export function stubFetch(
       if (matchesResult instanceof Promise) {
         await matchesResult;
       }
-      return Promise.resolve(response.clone());
+      const cloned = response.clone();
+      return new Response(cloned.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: new Headers(response.headers),
+      });
     },
   );
 }


### PR DESCRIPTION
### Summary

This pull request fixes a `test (v2.x)` failure in the Deno CI matrix caused by a `Response.clone()` behavior change on Deno 2.x.

- On Deno 2.x, `Response.clone()` **drops headers set from a plain object literal** (e.g. `{ "Content-Type": "application/json" }`). Headers set via a `Headers` instance survive.
- `stubFetch` returned `response.clone()` directly, so a stubbed response built with plain-object headers lost its `Content-Type` — breaking `testing/http_test.ts` on `v2.x` (`response.headers.get("Content-Type")` returned `null`).
- Fix: reconstruct the response from a fresh `new Headers(response.headers)` copy so the stub preserves headers regardless of how the caller built the `Response`.
- Also set `fail-fast: false` on the Deno test matrix — the `v2.x` failure was cancelling the `v1.x` and `v1.46.2` jobs, hiding that those versions actually passed.

### testing

- Check out this branch and run `deno task test` — the full suite (fmt, lint, 37 tests) passes on Deno 2.x, where `stubFetch`'s "should replace global fetch with a stub" previously failed.
- Confirm the Deno CI matrix now reports each version (`v1.x`, `v1.46.2`, `v2.x`) independently rather than cancelling siblings on first failure.

### Special notes

Root cause isolated with a minimal repro: a `Response` built with `headers: { "Content-Type": "application/json" }` returns `null` for that header after `.clone()` on Deno 2.x, while the same built with `new Headers({...})` preserves it.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/deno-slack-api/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've ran `deno task test` after making the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)